### PR TITLE
[SWM-113] feat: fl_chart 1.0.0으로 업그레이드 및 히스토리 탭 API 연동 및 기간 선택 구현

### DIFF
--- a/lib/src/models/history_data.dart
+++ b/lib/src/models/history_data.dart
@@ -8,6 +8,21 @@ class HistoryDataPoint {
     required this.date,
     required this.experience,
   });
+
+  /// 서버 응답에서 생성 (날짜 문자열 -> DateTime 변환, value -> experience)
+  factory HistoryDataPoint.fromJson(Map<String, dynamic> json) {
+    return HistoryDataPoint(
+      date: DateTime.parse(json['date']),
+      experience: (json['value'] ?? 0).toDouble(), // 서버의 'value' -> 'experience'
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'date': date.toIso8601String().split('T')[0], // YYYY-MM-DD 형태로
+      'value': experience, // experience -> 'value'로 변환
+    };
+  }
 }
 
 // 히스토리 정보
@@ -26,49 +41,44 @@ class HistoryData {
     required this.maxDaily,
   });
 
-  // 임시 데이터 생성 함수
-  static HistoryData generateMockData() {
-    final now = DateTime.now();
-    
-    // 역동적인 30일간의 경험치 데이터 (왔다갔다하면서 우상향)
-    final dataPoints = <HistoryDataPoint>[
-      HistoryDataPoint(date: now.subtract(const Duration(days: 29)), experience: 1280.0), // 시작
-      HistoryDataPoint(date: now.subtract(const Duration(days: 28)), experience: 1320.0), // +40 좋은 시작
-      HistoryDataPoint(date: now.subtract(const Duration(days: 27)), experience: 1285.0), // -35 실수로 감소
-      HistoryDataPoint(date: now.subtract(const Duration(days: 26)), experience: 1365.0), // +80 큰 성과
-      HistoryDataPoint(date: now.subtract(const Duration(days: 25)), experience: 1340.0), // -25 하락
-      HistoryDataPoint(date: now.subtract(const Duration(days: 24)), experience: 1410.0), // +70 회복
-      HistoryDataPoint(date: now.subtract(const Duration(days: 23)), experience: 1390.0), // -20 소폭 하락
-      HistoryDataPoint(date: now.subtract(const Duration(days: 22)), experience: 1480.0), // +90 큰 점프
-      HistoryDataPoint(date: now.subtract(const Duration(days: 21)), experience: 1455.0), // -25 조정
-      HistoryDataPoint(date: now.subtract(const Duration(days: 20)), experience: 1520.0), // +65 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 19)), experience: 1610.0), // +90 큰 성장
-      HistoryDataPoint(date: now.subtract(const Duration(days: 18)), experience: 1580.0), // -30 소폭 하락
-      HistoryDataPoint(date: now.subtract(const Duration(days: 17)), experience: 1665.0), // +85 반등
-      HistoryDataPoint(date: now.subtract(const Duration(days: 16)), experience: 1640.0), // -25 조정
-      HistoryDataPoint(date: now.subtract(const Duration(days: 15)), experience: 1720.0), // +80 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 14)), experience: 1795.0), // +75 지속 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 13)), experience: 1765.0), // -30 하락
-      HistoryDataPoint(date: now.subtract(const Duration(days: 12)), experience: 1850.0), // +85 큰 회복
-      HistoryDataPoint(date: now.subtract(const Duration(days: 11)), experience: 1825.0), // -25 소폭 조정
-      HistoryDataPoint(date: now.subtract(const Duration(days: 10)), experience: 1915.0), // +90 큰 성장
-      HistoryDataPoint(date: now.subtract(const Duration(days: 9)), experience: 1890.0),  // -25 하락
-      HistoryDataPoint(date: now.subtract(const Duration(days: 8)), experience: 1970.0),  // +80 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 7)), experience: 2055.0),  // +85 지속 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 6)), experience: 2025.0),  // -30 조정
-      HistoryDataPoint(date: now.subtract(const Duration(days: 5)), experience: 2110.0),  // +85 회복
-      HistoryDataPoint(date: now.subtract(const Duration(days: 4)), experience: 2180.0),  // +70 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 3)), experience: 2155.0),  // -25 소폭 하락
-      HistoryDataPoint(date: now.subtract(const Duration(days: 2)), experience: 2240.0),  // +85 큰 성장
-      HistoryDataPoint(date: now.subtract(const Duration(days: 1)), experience: 2320.0),  // +80 지속 상승
-      HistoryDataPoint(date: now.subtract(const Duration(days: 0)), experience: 2365.0),  // +45 마무리
-    ];
-    
+  /// 서버 응답 데이터에서 생성 (통계는 자동 계산)
+  factory HistoryData.fromJson(List<dynamic> jsonList) {
+    final dataPoints = jsonList
+        .map((json) => HistoryDataPoint.fromJson(json as Map<String, dynamic>))
+        .toList();
+
+    // 통계 자동 계산
+    if (dataPoints.isEmpty) {
+      return HistoryData(
+        dataPoints: dataPoints,
+        totalIncrease: 0.0,
+        averageDaily: 0.0,
+        maxDaily: 0.0,
+      );
+    }
+
+    final firstValue = dataPoints.first.experience;
+    final lastValue = dataPoints.last.experience;
+    final totalIncrease = lastValue - firstValue;
+
+    double maxDaily = 0.0;
+    for (int i = 1; i < dataPoints.length; i++) {
+      final dailyChange = (dataPoints[i].experience - dataPoints[i - 1].experience).abs();
+      if (dailyChange > maxDaily) {
+        maxDaily = dailyChange;
+      }
+    }
+
+    final averageDaily = dataPoints.length > 1 
+        ? totalIncrease / (dataPoints.length - 1)
+        : 0.0;
+
     return HistoryData(
       dataPoints: dataPoints,
-      totalIncrease: 1085.0, // 2365.0 - 1280.0
-      averageDaily: 36.2,    // 1085.0 / 30
-      maxDaily: 90.0,        // 최대 일일 증가량
+      totalIncrease: totalIncrease,
+      averageDaily: averageDaily,
+      maxDaily: maxDaily,
     );
   }
+
 } 

--- a/lib/src/models/user_profile.dart
+++ b/lib/src/models/user_profile.dart
@@ -1,0 +1,61 @@
+/// 사용자 프로필 정보를 담는 모델
+class UserProfile {
+  final String nickname;
+  final String statusMessage;
+  final String? profileImageUrl;
+  final int ranking;
+  final int rating;
+  final Map<String, int> categoryRatings;
+  final int currentStreak;
+  final int longestStreak;
+  final int solvedProblemsCount;
+  final int rivalCount;
+
+  UserProfile({
+    required this.nickname,
+    required this.statusMessage,
+    this.profileImageUrl,
+    required this.ranking,
+    required this.rating,
+    required this.categoryRatings,
+    required this.currentStreak,
+    required this.longestStreak,
+    required this.solvedProblemsCount,
+    required this.rivalCount,
+  });
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      nickname: json['nickname'] ?? '',
+      statusMessage: json['statusMessage'] ?? '',
+      profileImageUrl: json['profileImageUrl'],
+      ranking: json['ranking'] ?? 0,
+      rating: json['rating'] ?? 0,
+      categoryRatings: Map<String, int>.from(json['categoryRatings'] ?? {}),
+      currentStreak: json['currentStreak'] ?? 0,
+      longestStreak: json['longestStreak'] ?? 0,
+      solvedProblemsCount: json['solvedProblemsCount'] ?? 0,
+      rivalCount: json['rivalCount'] ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'nickname': nickname,
+      'statusMessage': statusMessage,
+      'profileImageUrl': profileImageUrl,
+      'ranking': ranking,
+      'rating': rating,
+      'categoryRatings': categoryRatings,
+      'currentStreak': currentStreak,
+      'longestStreak': longestStreak,
+      'solvedProblemsCount': solvedProblemsCount,
+      'rivalCount': rivalCount,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'UserProfile(nickname: $nickname, ranking: $ranking, rating: $rating, streak: $currentStreak)';
+  }
+} 

--- a/lib/src/services/api_client.dart
+++ b/lib/src/services/api_client.dart
@@ -30,10 +30,10 @@ class ApiResponse<T> {
 /// Dio 기반 API 클라이언트
 class ApiClient {
   static final String _baseUrl = dotenv.env['BASE_URL'] ?? '';
-  
+
   late final Dio _dio;
   static ApiClient? _instance;
-  
+
   // 401 에러 발생 시 호출할 콜백 함수
   Function()? onUnauthorized;
 
@@ -44,16 +44,18 @@ class ApiClient {
   }
 
   ApiClient._internal() {
-    _dio = Dio(BaseOptions(
-      baseUrl: _baseUrl,
-      connectTimeout: const Duration(seconds: 5),
-      receiveTimeout: const Duration(seconds: 10),
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-      },
-    ));
-    
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: _baseUrl,
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      ),
+    );
+
     _setupInterceptors();
   }
 
@@ -66,7 +68,7 @@ class ApiClient {
           if (token != null) {
             options.headers['Authorization'] = 'Bearer $token';
           }
-          
+
           // 요청 로깅 (개발 모드에서만)
           if (kDebugMode) {
             developer.log(
@@ -77,7 +79,7 @@ class ApiClient {
               developer.log('Body: ${options.data}', name: 'ApiClient');
             }
           }
-          
+
           handler.next(options);
         },
         onResponse: (response, handler) {
@@ -100,7 +102,7 @@ class ApiClient {
 
   void _handleApiError(DioException error) {
     final statusCode = error.response?.statusCode ?? 0;
-    
+
     developer.log(
       'API Error: $statusCode - ${error.message}',
       name: 'ApiClient',
@@ -125,7 +127,7 @@ class ApiClient {
   ) {
     try {
       final statusCode = response.statusCode ?? 0;
-      
+
       // 응답 실패 시 바로 리턴
       if (statusCode < 200 || statusCode >= 300) {
         return ApiResponse.failure('요청 처리 중 오류가 발생했습니다.', statusCode);
@@ -142,16 +144,23 @@ class ApiClient {
       }
 
       final responseData = response.data as Map<String, dynamic>;
-      final httpStatus = responseData['httpStatus'] as int;
-      
+
+      // 새로운 API 구조: body 필드 확인
+      final bodyData = responseData['body'] as Map<String, dynamic>?;
+      if (bodyData == null) {
+        return ApiResponse.failure('응답 구조가 올바르지 않습니다.', statusCode);
+      }
+
+      final httpStatus = bodyData['httpStatus'] as int;
+
       // httpStatus가 실패일 때 바로 리턴
       if (httpStatus < 200 || httpStatus >= 300) {
-        final statusMessage = responseData['statusMessage'] ?? '요청 처리 실패';
+        final statusMessage = bodyData['statusMessage'] ?? '요청 처리 실패';
         return ApiResponse.failure(statusMessage, httpStatus);
       }
 
       // 성공 케이스 - data 필드 추출
-      final actualData = responseData['data'];
+      final actualData = bodyData['data'];
       
       // fromJson이 있으면 변환, 없으면 data를 그대로 반환
       if (fromJson != null) {
@@ -197,17 +206,17 @@ class ApiClient {
       if (responseData is! Map<String, dynamic>) {
         return _getDefaultErrorMessage(statusCode);
       }
-      
+
       // statusMessage 키가 있으면 바로 리턴
       if (responseData.containsKey('statusMessage')) {
         return responseData['statusMessage'];
       }
-      
+
       // message 키가 있으면 바로 리턴
       if (responseData.containsKey('message')) {
         return responseData['message'];
       }
-      
+
       // error 키가 있으면 바로 리턴
       if (responseData.containsKey('error')) {
         return responseData['error'];

--- a/lib/src/services/user_query_service.dart
+++ b/lib/src/services/user_query_service.dart
@@ -1,3 +1,4 @@
+import '../models/user_profile.dart';
 import 'user_service.dart';
 import 'auth_service.dart';
 

--- a/lib/src/widgets/history_chart.dart
+++ b/lib/src/widgets/history_chart.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../models/history_data.dart';
 import '../utils/tier_colors.dart';
+import 'dart:math';
 
-class HistoryChart extends StatelessWidget {
+class HistoryChart extends StatefulWidget {
   final HistoryData historyData;
   final TierColorScheme colorScheme;
 
@@ -14,7 +15,80 @@ class HistoryChart extends StatelessWidget {
   });
 
   @override
+  State<HistoryChart> createState() => _HistoryChartState();
+}
+
+class _HistoryChartState extends State<HistoryChart>
+    with TickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 800),
+      vsync: this,
+    );
+    _animation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+    _controller.forward();
+  }
+
+  @override
+  void didUpdateWidget(HistoryChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.historyData != widget.historyData) {
+      _controller.reset();
+      _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  // 자동 최적화 함수 추가
+  double getNiceInterval(double min, double max, int targetTicks) {
+    final rawInterval = (max - min) / targetTicks;
+    if (rawInterval == 0) return 1;
+    final magnitude = pow(10, (log(rawInterval) / ln10).floor()).toDouble();
+    final residual = rawInterval / magnitude;
+    double niceInterval;
+    if (residual > 5) {
+      niceInterval = 10 * magnitude;
+    } else if (residual > 2) {
+      niceInterval = 5 * magnitude;
+    } else if (residual > 1) {
+      niceInterval = 2 * magnitude;
+    } else {
+      niceInterval = magnitude;
+    }
+    return niceInterval;
+  }
+
+  @override
   Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        return _buildChart();
+      },
+    );
+  }
+
+  Widget _buildChart() {
+    final minY = _getMinY();
+    final maxY = _getMaxY();
+    final yInterval = getNiceInterval(minY, maxY, 6); // 6개 눈금 기준
+    final dataCount = widget.historyData.dataPoints.length;
+    // labelIndexes 계산 (0, 중간들, 마지막)
+    final labelIndexes = getLabelIndexes(dataCount);
+
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 20),
       padding: const EdgeInsets.all(20),
@@ -48,7 +122,7 @@ class HistoryChart extends StatelessWidget {
                 gridData: FlGridData(
                   show: true,
                   drawVerticalLine: false,
-                  horizontalInterval: 400,
+                  horizontalInterval: yInterval,
                   getDrawingHorizontalLine: (value) {
                     return const FlLine(
                       color: Color(0xFFF1F5F9),
@@ -68,29 +142,30 @@ class HistoryChart extends StatelessWidget {
                     sideTitles: SideTitles(
                       showTitles: true,
                       reservedSize: 30,
-                      interval: 7,
-                      getTitlesWidget: _getBottomTitles,
+                      interval: 1,
+                      getTitlesWidget: (value, meta) =>
+                          _getBottomTitles(value, meta, labelIndexes),
                     ),
                   ),
                   leftTitles: AxisTitles(
                     sideTitles: SideTitles(
                       showTitles: true,
                       reservedSize: 50,
-                      interval: 400,
+                      interval: yInterval,
                       getTitlesWidget: _getLeftTitles,
                     ),
                   ),
                 ),
                 borderData: FlBorderData(show: false),
                 minX: 0,
-                maxX: (historyData.dataPoints.length - 1).toDouble(),
-                minY: _getMinY(),
-                maxY: _getMaxY(),
+                maxX: (widget.historyData.dataPoints.length - 1).toDouble(),
+                minY: minY,
+                maxY: maxY,
                 lineBarsData: [
                   LineChartBarData(
-                    spots: _getSpots(),
+                    spots: _getAnimatedSpots(),
                     isCurved: true,
-                    gradient: colorScheme.gradient,
+                    gradient: widget.colorScheme.gradient,
                     barWidth: 3,
                     isStrokeCapRound: true,
                     dotData: const FlDotData(show: false),
@@ -100,11 +175,10 @@ class HistoryChart extends StatelessWidget {
                   enabled: true,
                   touchTooltipData: LineTouchTooltipData(
                     getTooltipColor: (touchedSpot) => const Color(0xFF1E293B),
-                    tooltipRoundedRadius: 8,
                     getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
                       return touchedBarSpots.map((barSpot) {
                         final dataPoint =
-                            historyData.dataPoints[barSpot.x.toInt()];
+                            widget.historyData.dataPoints[barSpot.x.toInt()];
                         return LineTooltipItem(
                           '${dataPoint.date.month}/${dataPoint.date.day}\n',
                           const TextStyle(
@@ -116,7 +190,7 @@ class HistoryChart extends StatelessWidget {
                             TextSpan(
                               text: '${dataPoint.experience.toInt()} EXP',
                               style: TextStyle(
-                                color: colorScheme.primary,
+                                color: widget.colorScheme.primary,
                                 fontWeight: FontWeight.w700,
                                 fontSize: 14,
                               ),
@@ -135,47 +209,55 @@ class HistoryChart extends StatelessWidget {
     );
   }
 
-  // 점 데이터 가져오기
-  List<FlSpot> _getSpots() {
-    return historyData.dataPoints.asMap().entries.map((entry) {
-      return FlSpot(entry.key.toDouble(), entry.value.experience);
-    }).toList();
+  // 애니메이션된 점 데이터 가져오기
+  List<FlSpot> _getAnimatedSpots() {
+    // 애니메이션 진행도에 따라 몇 개의 점만 포함
+    final maxVisibleIndex =
+        (widget.historyData.dataPoints.length * _animation.value).floor();
+
+    return widget.historyData.dataPoints
+        .asMap()
+        .entries
+        .take(maxVisibleIndex + 1) // 애니메이션 진행도에 따라 점 개수 제한
+        .map((entry) {
+          final index = entry.key;
+          final dataPoint = entry.value;
+          return FlSpot(index.toDouble(), dataPoint.experience);
+        })
+        .toList();
   }
 
   double _getMinY() {
-    final minExp = historyData.dataPoints
+    final minExp = widget.historyData.dataPoints
         .map((e) => e.experience)
         .reduce((a, b) => a < b ? a : b);
     return (minExp - 50).floorToDouble();
   }
 
   double _getMaxY() {
-    final maxExp = historyData.dataPoints
+    final maxExp = widget.historyData.dataPoints
         .map((e) => e.experience)
         .reduce((a, b) => a > b ? a : b);
     return (maxExp + 50).ceilToDouble();
   }
 
   // 하단 타이틀 가져오기
-  Widget _getBottomTitles(double value, TitleMeta meta) {
+  Widget _getBottomTitles(
+    double value,
+    TitleMeta meta,
+    List<int> labelIndexes,
+  ) {
     final index = value.toInt();
-
-    // 범위 체크
-    if (index >= historyData.dataPoints.length) return Container();
-
-    // 마지막 인덱스 체크 (글자 겹침 방지)
-    if (index == historyData.dataPoints.length - 1) return Container();
-
-    final dataPoint = historyData.dataPoints[index];
-    return SideTitleWidget(
-      axisSide: meta.axisSide,
-      child: Text(
-        '${dataPoint.date.month}/${dataPoint.date.day}',
-        style: const TextStyle(
-          color: Color(0xFF64748B),
-          fontSize: 11,
-          fontWeight: FontWeight.w500,
-        ),
+    final dataCount = widget.historyData.dataPoints.length;
+    if (index >= dataCount) return Container();
+    if (!labelIndexes.contains(index)) return Container();
+    final dataPoint = widget.historyData.dataPoints[index];
+    return Text(
+      '${dataPoint.date.month}/${dataPoint.date.day}',
+      style: const TextStyle(
+        color: Color(0xFF64748B),
+        fontSize: 11,
+        fontWeight: FontWeight.w500,
       ),
     );
   }
@@ -189,16 +271,26 @@ class HistoryChart extends StatelessWidget {
       return Container();
     }
 
-    return SideTitleWidget(
-      axisSide: meta.axisSide,
-      child: Text(
-        '${value.toInt()}',
-        style: const TextStyle(
-          color: Color(0xFF64748B),
-          fontSize: 11,
-          fontWeight: FontWeight.w500,
-        ),
+    return Text(
+      '${value.toInt()}',
+      style: const TextStyle(
+        color: Color(0xFF64748B),
+        fontSize: 11,
+        fontWeight: FontWeight.w500,
       ),
     );
+  }
+
+  List<int> getLabelIndexes(int dataLength) {
+    if (dataLength <= 1) return [0];
+    if (dataLength == 2) return [0, 1];
+    if (dataLength == 3) return [0, 1, 2];
+    // 4개 이상일 때: 0, 중간1, 중간2, 마지막 (최대 4~5개)
+    final last = dataLength - 1;
+    final mid1 = (last / 3).round();
+    final mid2 = (last * 2 / 3).round();
+    final set = <int>{0, mid1, mid2, last};
+    final sorted = set.toList()..sort();
+    return sorted;
   }
 }

--- a/lib/src/widgets/history_period_selector.dart
+++ b/lib/src/widgets/history_period_selector.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import '../utils/tier_colors.dart';
+import 'history_widget.dart';
 
 class HistoryPeriodSelector extends StatelessWidget {
-  final String selectedPeriod;
-  final Function(String) onPeriodChanged;
+  final HistoryPeriod selectedPeriod;
+  final Function(HistoryPeriod) onPeriodChanged;
   final TierColorScheme colorScheme;
 
   const HistoryPeriodSelector({
@@ -15,7 +16,7 @@ class HistoryPeriodSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final periods = ['전체', '6개월', '1개월', '1주', '1일'];
+    const periods = HistoryPeriod.values;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -36,7 +37,7 @@ class HistoryPeriodSelector extends StatelessWidget {
                     : Border.all(color: const Color(0xFFE2E8F0), width: 1),
               ),
               child: Text(
-                period,
+                period.label,
                 style: TextStyle(
                   color: isSelected ? Colors.white : const Color(0xFF64748B),
                   fontSize: 13,
@@ -49,4 +50,4 @@ class HistoryPeriodSelector extends StatelessWidget {
       ),
     );
   }
-} 
+}

--- a/lib/src/widgets/history_widget.dart
+++ b/lib/src/widgets/history_widget.dart
@@ -1,9 +1,50 @@
 import 'package:flutter/material.dart';
 import '../models/history_data.dart';
+import '../services/user_service.dart';
 import '../utils/tier_colors.dart';
 import 'history_period_selector.dart';
 import 'history_chart.dart';
 import 'history_stats_summary.dart';
+
+enum HistoryPeriod {
+  all, // 전체
+  oneYear, // 1년
+  sixMonths, // 6개월
+  oneMonth, // 1개월
+  oneWeek, // 1주
+}
+
+extension HistoryPeriodExtension on HistoryPeriod {
+  String get label {
+    switch (this) {
+      case HistoryPeriod.all:
+        return '전체';
+      case HistoryPeriod.oneYear:
+        return '1년';
+      case HistoryPeriod.sixMonths:
+        return '6개월';
+      case HistoryPeriod.oneMonth:
+        return '1개월';
+      case HistoryPeriod.oneWeek:
+        return '1주';
+    }
+  }
+
+  Duration? get duration {
+    switch (this) {
+      case HistoryPeriod.all:
+        return null;
+      case HistoryPeriod.oneYear:
+        return const Duration(days: 365);
+      case HistoryPeriod.sixMonths:
+        return const Duration(days: 180);
+      case HistoryPeriod.oneMonth:
+        return const Duration(days: 30);
+      case HistoryPeriod.oneWeek:
+        return const Duration(days: 7);
+    }
+  }
+}
 
 class HistoryWidget extends StatefulWidget {
   final String tierName;
@@ -18,14 +59,62 @@ class HistoryWidget extends StatefulWidget {
 }
 
 class _HistoryWidgetState extends State<HistoryWidget> {
-  String selectedPeriod = '1개월';
-  late HistoryData historyData;
+  HistoryPeriod selectedPeriod = HistoryPeriod.oneMonth;
+  HistoryData? historyData;
+  bool isLoading = true;
+  String? error;
 
   @override
   void initState() {
     super.initState();
-    // 임시 데이터 로드
-    historyData = HistoryData.generateMockData();
+    _loadHistoryData();
+  }
+
+  /// 히스토리 데이터 로드
+  Future<void> _loadHistoryData() async {
+    if (!mounted) return;
+
+    setState(() {
+      isLoading = true;
+      error = null;
+    });
+
+    try {
+      final response = await UserService.getCurrentUserHistory(
+          criteria: 'RATING');
+
+      if (!mounted) return;
+
+      if (response.success && response.data != null) {
+        setState(() {
+          historyData = response.data!;
+          isLoading = false;
+        });
+      } else {
+        setState(() {
+          error = response.error ?? '데이터를 불러올 수 없습니다';
+          isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        error = '네트워크 오류가 발생했습니다';
+        isLoading = false;
+      });
+    }
+  }
+
+  List<HistoryDataPoint> getFilteredDataPoints() {
+    if (historyData == null) return [];
+    final duration = selectedPeriod.duration;
+    final now = DateTime.now();
+    // 오름차순 정렬 후 필터링
+    final sorted = [...historyData!.dataPoints]
+      ..sort((a, b) => a.date.compareTo(b.date));
+    if (duration == null) return sorted;
+    return sorted.where((e) => e.date.isAfter(now.subtract(duration))).toList();
   }
 
   @override
@@ -33,11 +122,25 @@ class _HistoryWidgetState extends State<HistoryWidget> {
     final TierType tierType = TierColors.getTierFromString(widget.tierName);
     final TierColorScheme colorScheme = TierColors.getColorScheme(tierType);
 
+    final filteredPoints = getFilteredDataPoints();
+    final filteredHistoryData = HistoryData(
+      dataPoints: filteredPoints,
+      totalIncrease: filteredPoints.isNotEmpty ? filteredPoints.last
+          .experience - filteredPoints.first.experience : 0.0,
+      averageDaily: filteredPoints.length > 1 ? (filteredPoints.last
+          .experience - filteredPoints.first.experience) /
+          (filteredPoints.length - 1) : 0.0,
+      maxDaily: filteredPoints.length > 1 ? List.generate(
+          filteredPoints.length - 1, (i) =>
+          (filteredPoints[i + 1].experience - filteredPoints[i].experience)
+              .abs()).reduce((a, b) => a > b ? a : b) : 0.0,
+    );
+
     return SingleChildScrollView(
       child: Column(
         children: [
           const SizedBox(height: 8),
-          
+
           // 기간 선택
           HistoryPeriodSelector(
             selectedPeriod: selectedPeriod,
@@ -45,27 +148,63 @@ class _HistoryWidgetState extends State<HistoryWidget> {
               setState(() {
                 selectedPeriod = period;
               });
-              // TODO: 실제 데이터 연동 시 여기서 데이터 재로드
             },
             colorScheme: colorScheme,
           ),
-          
+
           const SizedBox(height: 8),
-          
-          // 경험치 변화 그래프
-          HistoryChart(
-            historyData: historyData,
-            colorScheme: colorScheme,
-          ),
-          
-          const SizedBox(height: 8),
-          
-          // 통계 요약
-          HistoryStatsSummary(
-            historyData: historyData,
-            colorScheme: colorScheme,
-          ),
-          
+
+          // 로딩, 에러, 데이터 상태 처리
+          if (isLoading)
+            const Padding(
+              padding: EdgeInsets.all(40.0),
+              child: CircularProgressIndicator(),
+            )
+          else
+            if (error != null)
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      size: 48,
+                      color: Colors.grey[400],
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      error!,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 16,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: _loadHistoryData,
+                      child: const Text('다시 시도'),
+                    ),
+                  ],
+                ),
+              )
+            else
+              if (historyData != null) ...[
+                // 경험치 변화 그래프
+                HistoryChart(
+                  historyData: filteredHistoryData,
+                  colorScheme: colorScheme,
+                ),
+
+                const SizedBox(height: 8),
+
+                // 통계 요약
+                HistoryStatsSummary(
+                  historyData: filteredHistoryData,
+                  colorScheme: colorScheme,
+                ),
+              ],
+
           const SizedBox(height: 20),
         ],
       ),

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -6,7 +6,7 @@ import 'tier_widget.dart';
 import 'history_widget.dart';
 import 'streak_widget.dart';
 import '../utils/tier_colors.dart';
-import '../services/user_service.dart';
+import '../models/user_profile.dart';
 import '../services/user_query_service.dart';
 
 class ProfileBody extends HookWidget {

--- a/lib/src/widgets/profile_header.dart
+++ b/lib/src/widgets/profile_header.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../utils/tier_colors.dart';
-import '../services/user_service.dart';
+import '../models/user_profile.dart';
 
 class ProfileHeader extends StatelessWidget {
   final UserProfile? userProfile;

--- a/lib/src/widgets/streak_widget.dart
+++ b/lib/src/widgets/streak_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../utils/tier_colors.dart';
-import '../services/user_service.dart';
+import '../models/user_profile.dart';
 
 class StreakWidget extends StatelessWidget {
   final String tierName;

--- a/lib/src/widgets/tier_widget.dart
+++ b/lib/src/widgets/tier_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../utils/tier_colors.dart';
-import '../services/user_service.dart';
+import '../models/user_profile.dart';
 
 class TierWidget extends StatelessWidget {
   final String tierName;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -237,10 +237,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: d0f0d49112f2f4b192481c16d05b6418bd7820e021e265a3c22db98acf7ed7fb
+      sha256: "577aeac8ca414c25333334d7c4bb246775234c0e44b38b10a82b559dd4d764e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.68.0"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -783,4 +783,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.27.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  fl_chart: ^0.68.0
+  fl_chart: ^1.0.0
   flutter_secure_storage: ^9.2.2
   http: ^1.1.0
   dio: ^5.7.0

--- a/test/unit/history_data_test.dart
+++ b/test/unit/history_data_test.dart
@@ -3,12 +3,39 @@ import 'package:climbx_fe/src/models/history_data.dart';
 
 void main() {
   group('History Data Model Tests', () {
-    test('Mock 데이터가 생성된다', () {
-      final historyData = HistoryData.generateMockData();
+    test('서버 응답 데이터를 올바르게 파싱한다', () {
+      // 서버 응답 형태의 더미 데이터
+      final jsonData = [
+        {'date': '2025-01-01', 'value': 1000},
+        {'date': '2025-01-02', 'value': 1050},
+        {'date': '2025-01-03', 'value': 1030},
+      ];
       
-      // 기본적으로 데이터가 생성되는지만 확인
+      final historyData = HistoryData.fromJson(jsonData);
+      
+      // 파싱 검증
       expect(historyData, isNotNull);
-      expect(historyData.dataPoints, isNotEmpty);
+      expect(historyData.dataPoints.length, equals(3));
+      expect(historyData.dataPoints.first.experience, equals(1000.0));
+      expect(historyData.dataPoints.last.experience, equals(1030.0));
+      expect(historyData.totalIncrease, equals(30.0)); // 1030 - 1000
+    });
+
+    test('HistoryDataPoint가 서버 응답을 올바르게 변환한다', () {
+      final json = {'date': '2025-01-01', 'value': 1500};
+      final dataPoint = HistoryDataPoint.fromJson(json);
+      
+      expect(dataPoint.date, equals(DateTime.parse('2025-01-01')));
+      expect(dataPoint.experience, equals(1500.0));
+    });
+
+    test('빈 데이터 목록을 올바르게 처리한다', () {
+      final historyData = HistoryData.fromJson([]);
+      
+      expect(historyData.dataPoints, isEmpty);
+      expect(historyData.totalIncrease, equals(0.0));
+      expect(historyData.averageDaily, equals(0.0));
+      expect(historyData.maxDaily, equals(0.0));
     });
   });
 } 


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 히스토리 그래프를 그리는 fl_chart의 버전을 업그레이드
- 유저데이터 스키마를 model/로 이동
- 히스토리 데이터 API로 받아와서 보여주는것을 구현
- 히스토리 탭의 날짜 이동을 적용
- 히스토리 탭의 날짜 이동시 애니메이션 적용
- json포맷에 맞게 API처리 공통로직 수정

## ✨ 변경 사항 (Changes)
- fl_chart 0.68.0 버전 -> fl_chart 1.0.0 버전
- 히스토리 탭 완전 구현 완료
- 히스토리 탭 

## 💬 리뷰어에게 (To Reviewer)
fl_chart 버전을 바꾸면서 이와 함께 현재파일들을 올렸습니다.
머지 이후 추가로 스트릭 탭을 구현해야합니다.

## 📋 앞으로의 과제 (Todo)
- 스트릭 API 연동 [SWM-114]

[SWM-114]: https://swm16.atlassian.net/browse/SWM-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ