### PR TITLE
[SWM-114] feat: 스트릭 탭 API연동

### DIFF
--- a/lib/src/api/user.dart
+++ b/lib/src/api/user.dart
@@ -56,13 +56,12 @@ class UserApi {
       if (from != null) queryParams['from'] = from;
       if (to != null) queryParams['to'] = to;
 
-      final data = await _apiClient.get<dynamic>(
+      return await _apiClient.get<HistoryData>(
         '/api/users/$nickname/history',
         queryParameters: queryParams,
+        fromJson: HistoryData.fromJson,
         logContext: 'UserApi',
       );
-
-      return HistoryData.fromJson(data);
     } catch (e) {
       // 디버깅용 상세 로그 남기기
       developer.log('히스토리 데이터 조회 실패: $e', name: 'UserApi', error: e);
@@ -96,13 +95,12 @@ class UserApi {
       if (from != null) queryParams['from'] = from;
       if (to != null) queryParams['to'] = to;
 
-      final data = await _apiClient.get<dynamic>(
+      return await _apiClient.get<StreakData>(
         '/api/users/$nickname/streak',
         queryParameters: queryParams,
+        fromJson: StreakData.fromJson,
         logContext: 'UserApi',
       );
-
-      return StreakData.fromJson(data);
     } catch (e) {
       // 디버깅용 상세 로그 남기기
       developer.log('스트릭 데이터 조회 실패: $e', name: 'UserApi', error: e);

--- a/lib/src/api/user.dart
+++ b/lib/src/api/user.dart
@@ -59,7 +59,7 @@ class UserApi {
       return await _apiClient.get<HistoryData>(
         '/api/users/$nickname/history',
         queryParameters: queryParams,
-        fromJson: HistoryData.fromJson,
+        fromJson: (data) => HistoryData.fromJson(data as List<dynamic>),
         logContext: 'UserApi',
       );
     } catch (e) {
@@ -98,7 +98,7 @@ class UserApi {
       return await _apiClient.get<StreakData>(
         '/api/users/$nickname/streak',
         queryParameters: queryParams,
-        fromJson: StreakData.fromJson,
+        fromJson: (data) => StreakData.fromJson(data as List<dynamic>),
         logContext: 'UserApi',
       );
     } catch (e) {

--- a/lib/src/api/user.dart
+++ b/lib/src/api/user.dart
@@ -29,10 +29,10 @@ class UserApi {
   }
 
   /// 특정 사용자 프로필 조회 (확장 가능)
-  static Future<UserProfile> getUserProfileByUsername(String username) async {
+  static Future<UserProfile> getUserProfileByNickname(String nickname) async {
     try {
       return await _apiClient.get<UserProfile>(
-        '/api/users/$username',
+        '/api/users/$nickname',
         fromJson: (data) => UserProfile.fromJson(data as Map<String, dynamic>),
         logContext: 'UserApi',
       );
@@ -45,7 +45,7 @@ class UserApi {
 
   /// 사용자 히스토리 조회 (queryParameters 방식 사용)
   static Future<HistoryData> getUserHistory({
-    String username = 'alice',
+    String nickname = 'alice',
     String? from,
     String? to,
     String criteria = 'RATING',
@@ -57,18 +57,12 @@ class UserApi {
       if (to != null) queryParams['to'] = to;
 
       final data = await _apiClient.get<dynamic>(
-        '/api/users/$username/history',
+        '/api/users/$nickname/history',
         queryParameters: queryParams,
         logContext: 'UserApi',
       );
 
-      // HistoryData는 List<dynamic>을 기대하므로 타입 체크
-      if (data is List) {
-        return HistoryData.fromJson(data);
-      } else {
-        developer.log('HistoryData: List가 아닌 데이터, 빈 리스트 사용', name: 'UserApi');
-        return HistoryData.fromJson([]);
-      }
+      return HistoryData.fromJson(data);
     } catch (e) {
       // 디버깅용 상세 로그 남기기
       developer.log('히스토리 데이터 조회 실패: $e', name: 'UserApi', error: e);
@@ -83,7 +77,7 @@ class UserApi {
     String criteria = 'RATING',
   }) async {
     return await getUserHistory(
-      username: 'alice',
+      nickname: 'alice',
       from: from,
       to: to,
       criteria: criteria,
@@ -92,7 +86,7 @@ class UserApi {
 
   /// 사용자 스트릭 조회 (queryParameters 방식 사용)
   static Future<StreakData> getUserStreak({
-    String username = 'alice',
+    String nickname = 'alice',
     String? from,
     String? to,
   }) async {
@@ -103,20 +97,12 @@ class UserApi {
       if (to != null) queryParams['to'] = to;
 
       final data = await _apiClient.get<dynamic>(
-        '/api/users/$username/streak',
+        '/api/users/$nickname/streak',
         queryParameters: queryParams,
         logContext: 'UserApi',
       );
 
-      // StreakData는 List<dynamic>을 기대하므로 타입 체크
-      if (data is List) {
-        final streakData = StreakData.fromJson(data);
-        developer.log('스트릭 데이터 ${streakData.items.length}개 조회 성공', name: 'UserApi');
-        return streakData;
-      } else {
-        developer.log('StreakData: List가 아닌 데이터, 빈 리스트 사용', name: 'UserApi');
-        return StreakData.fromJson([]);
-      }
+      return StreakData.fromJson(data);
     } catch (e) {
       // 디버깅용 상세 로그 남기기
       developer.log('스트릭 데이터 조회 실패: $e', name: 'UserApi', error: e);
@@ -130,7 +116,7 @@ class UserApi {
     String? to,
   }) async {
     return await getUserStreak(
-      username: 'alice',
+      nickname: 'alice',
       from: from,
       to: to,
     );

--- a/lib/src/api/user.dart
+++ b/lib/src/api/user.dart
@@ -17,7 +17,9 @@ class UserApi {
         logContext: 'UserApi',
       );
     } catch (e) {
-      throw Exception('프로필 정보를 불러올 수 없습니다: $e');
+      // 디버깅용 상세 로그 남기기
+      developer.log('프로필 조회 실패: $e', name: 'UserApi', error: e);
+      throw Exception('프로필 정보를 불러올 수 없습니다');
     }
   }
 
@@ -35,7 +37,9 @@ class UserApi {
         logContext: 'UserApi',
       );
     } catch (e) {
-      throw Exception('프로필 정보를 불러올 수 없습니다: $e');
+      // 디버깅용 상세 로그 남기기
+      developer.log('프로필 조회 실패: $e', name: 'UserApi', error: e);
+      throw Exception('프로필 정보를 불러올 수 없습니다');
     }
   }
 
@@ -66,7 +70,9 @@ class UserApi {
         return HistoryData.fromJson([]);
       }
     } catch (e) {
-      throw Exception('히스토리 데이터를 불러올 수 없습니다: $e');
+      // 디버깅용 상세 로그 남기기
+      developer.log('히스토리 데이터 조회 실패: $e', name: 'UserApi', error: e);
+      throw Exception('히스토리 데이터를 불러올 수 없습니다');
     }
   }
 
@@ -112,7 +118,9 @@ class UserApi {
         return StreakData.fromJson([]);
       }
     } catch (e) {
-      throw Exception('스트릭 데이터를 불러올 수 없습니다: $e');
+      // 디버깅용 상세 로그 남기기
+      developer.log('스트릭 데이터 조회 실패: $e', name: 'UserApi', error: e);
+      throw Exception('스트릭 데이터를 불러올 수 없습니다');
     }
   }
 

--- a/lib/src/api/user.dart
+++ b/lib/src/api/user.dart
@@ -2,6 +2,7 @@ import 'dart:developer' as developer;
 import 'util/core/api_client.dart';
 import '../models/user_profile.dart';
 import '../models/history_data.dart';
+import '../models/streak_data.dart';
 
 /// 사용자 관련 API 호출 함수들
 class UserApi {
@@ -80,6 +81,50 @@ class UserApi {
       from: from,
       to: to,
       criteria: criteria,
+    );
+  }
+
+  /// 사용자 스트릭 조회 (queryParameters 방식 사용)
+  static Future<StreakData> getUserStreak({
+    String username = 'alice',
+    String? from,
+    String? to,
+  }) async {
+    try {
+      // 쿼리 파라미터 구성
+      final queryParams = <String, String>{};
+      if (from != null) queryParams['from'] = from;
+      if (to != null) queryParams['to'] = to;
+
+      final data = await _apiClient.get<dynamic>(
+        '/api/users/$username/streak',
+        queryParameters: queryParams,
+        logContext: 'UserApi',
+      );
+
+      // StreakData는 List<dynamic>을 기대하므로 타입 체크
+      if (data is List) {
+        final streakData = StreakData.fromJson(data);
+        developer.log('스트릭 데이터 ${streakData.items.length}개 조회 성공', name: 'UserApi');
+        return streakData;
+      } else {
+        developer.log('StreakData: List가 아닌 데이터, 빈 리스트 사용', name: 'UserApi');
+        return StreakData.fromJson([]);
+      }
+    } catch (e) {
+      throw Exception('스트릭 데이터를 불러올 수 없습니다: $e');
+    }
+  }
+
+  /// 현재 사용자 스트릭 조회 (간편 메서드)
+  static Future<StreakData> getCurrentUserStreak({
+    String? from,
+    String? to,
+  }) async {
+    return await getUserStreak(
+      username: 'alice',
+      from: from,
+      to: to,
     );
   }
 } 

--- a/lib/src/models/streak_data.dart
+++ b/lib/src/models/streak_data.dart
@@ -65,13 +65,13 @@ class StreakData {
 
   /// 1차원 스트릭 데이터를 24주 x 7일 2차원 배열로 변환
   static List<List<int>> _convertToWeeklyGrid(List<StreakItem> items) {
-    const int weeks = 24;
-    const int daysPerWeek = 7;
+    const int WEEKS = 24;
+    const int DAYS_PER_WEEK = 7;
 
     // 24주 x 7일 배열 초기화 (기본값 0)
     final grid = List.generate(
-      weeks,
-      (week) => List.generate(daysPerWeek, (day) => 0),
+      WEEKS,
+      (week) => List.generate(DAYS_PER_WEEK, (day) => 0),
     );
 
     // 현재 날짜에서 정확히 24주 전의 월요일을 찾기 (GitHub 스타일)
@@ -84,7 +84,7 @@ class StreakData {
 
     // 24주 전의 월요일 (그리드의 시작점)
     final startDate = thisWeekMonday.subtract(
-      const Duration(days: (weeks - 1) * daysPerWeek),
+      const Duration(days: (WEEKS - 1) * DAYS_PER_WEEK),
     );
 
     // 각 스트릭 항목을 그리드에 매핑
@@ -92,11 +92,11 @@ class StreakData {
       final itemDate = DateTime(item.date.year, item.date.month, item.date.day);
       final daysDiff = itemDate.difference(startDate).inDays;
 
-      if (daysDiff >= 0 && daysDiff < weeks * daysPerWeek) {
-        final weekIndex = daysDiff ~/ daysPerWeek;
-        final dayIndex = daysDiff % daysPerWeek;
+      if (daysDiff >= 0 && daysDiff < WEEKS * DAYS_PER_WEEK) {
+        final weekIndex = daysDiff ~/ DAYS_PER_WEEK;
+        final dayIndex = daysDiff % DAYS_PER_WEEK;
 
-        if (weekIndex < weeks && dayIndex < daysPerWeek) {
+        if (weekIndex < WEEKS && dayIndex < DAYS_PER_WEEK) {
           grid[weekIndex][dayIndex] = item.value;
         }
       }
@@ -107,72 +107,118 @@ class StreakData {
 
   /// 스트릭 통계 계산
   static Map<String, int> _calculateStats(List<StreakItem> items) {
+    // 데이터가 없는 경우 기본값 반환
     if (items.isEmpty) {
       return {'currentStreak': 0, 'longestStreak': 0, 'totalDays': 0};
     }
 
-    // 날짜순 정렬
-    final sortedItems = [...items]..sort((a, b) => a.date.compareTo(b.date));
+    // 날짜순 정렬 (과거 -> 최신)
+    final sortedItems = [...items]..sort((item1, item2) => item1.date.compareTo(item2.date));
 
-    // 현재 스트릭 계산
-    int currentStreak = 0;
-    int longestStreak = 0;
-    int tempStreak = 0;
-    DateTime? lastDate;
-
+    // 주별 기록 여부 맵 생성 (key: 주의 시작일(일요일), value: 기록 여부)
+    final weekMap = <DateTime, bool>{};
     for (final item in sortedItems) {
-      if (item.value > 0) {
-        if (lastDate != null) {
-          final daysDiff = item.date.difference(lastDate).inDays;
-          if (daysDiff == 1) {
-            // 연속된 날짜
-            tempStreak++;
-          } else {
-            // 연속이 끊김
-            longestStreak = tempStreak > longestStreak
-                ? tempStreak
-                : longestStreak;
-            tempStreak = 1;
-          }
-        } else {
-          // 첫 번째 항목
-          tempStreak = 1;
-        }
-        lastDate = item.date;
-      }
+      if (item.value <= 0) continue;
+      
+      // 해당 날짜가 속한 주의 시작일(일요일) 계산
+      final weekStart = _getWeekStart(item.date);
+      weekMap[weekStart] = true;
     }
 
-    // 마지막 스트릭 체크
-    longestStreak = tempStreak > longestStreak ? tempStreak : longestStreak;
+    // 주별 기록을 날짜순으로 정렬
+    final weekDates = weekMap.keys.toList()..sort();
 
-    // 현재 스트릭 계산 (오늘까지 연속인지 확인)
-    final today = DateTime.now();
-    final todayDateOnly = DateTime(today.year, today.month, today.day);
-
-    if (lastDate != null) {
-      final lastDateOnly = DateTime(
-        lastDate.year,
-        lastDate.month,
-        lastDate.day,
-      );
-      final daysDiff = todayDateOnly.difference(lastDateOnly).inDays;
-
-      if (daysDiff <= 1) {
-        // 어제 또는 오늘까지 연속
-        currentStreak = tempStreak;
-      } else {
-        currentStreak = 0;
-      }
-    }
-
-    // 총 제출일수 계산
-    final totalDays = sortedItems.where((item) => item.value > 0).length;
+    // 각각의 통계 계산
+    final longestStreak = _calculateLongestStreak(weekDates);
+    final currentStreak = _calculateCurrentStreak(weekMap);
+    final totalDays = _calculateTotalDays(sortedItems);
 
     return {
       'currentStreak': currentStreak,
       'longestStreak': longestStreak,
       'totalDays': totalDays,
     };
+  }
+
+  /// 최장 연속 주간 스트릭 계산
+  static int _calculateLongestStreak(List<DateTime> weekDates) {
+    if (weekDates.isEmpty) return 0;
+
+    // 스트릭 카운트 변수들
+    int longestStreak = 0;  // 가장 길었던 연속 주간 스트릭
+    int tempStreak = 0;     // 현재까지의 연속 주간 스트릭
+    DateTime? lastWeek;     // 마지막으로 기록된 주
+
+    // 주별 기록을 순회하며 연속 스트릭 계산
+    for (final weekStart in weekDates) {
+      if (lastWeek == null) {
+        tempStreak = 1;
+        lastWeek = weekStart;
+        continue;
+      }
+
+      // 이전 주와의 차이 계산 (7일이면 연속된 주)
+      final weekDiff = weekStart.difference(lastWeek).inDays;
+      if (weekDiff == 7) {
+        // 연속된 주간 기록
+        tempStreak++;
+      } else {
+        // 연속이 끊긴 경우 최장 기록 업데이트 후 새로운 스트릭 시작
+        longestStreak = tempStreak > longestStreak ? tempStreak : longestStreak;
+        tempStreak = 1;
+      }
+      lastWeek = weekStart;
+    }
+
+    // 마지막 스트릭이 최장 기록인지 확인
+    return tempStreak > longestStreak ? tempStreak : longestStreak;
+  }
+
+  /// 현재 진행 중인 스트릭 계산
+  static int _calculateCurrentStreak(Map<DateTime, bool> weekMap) {
+    if (weekMap.isEmpty) return 0;
+
+    final today = DateTime.now();
+    final currentWeekStart = _getWeekStart(today);
+    final lastWeekStart = _getWeekStart(today.subtract(const Duration(days: 7)));
+
+    // 이번 주에 방문 기록이 있으면 스트릭 유지
+    if (weekMap.containsKey(currentWeekStart)) {
+      return _getStreakLength(weekMap, currentWeekStart);
+    }
+
+    // 지난 주에 방문했으면 스트릭 유지 (이번 주는 아직 기회 있음)
+    if (weekMap.containsKey(lastWeekStart)) {
+      return _getStreakLength(weekMap, lastWeekStart);
+    }
+
+    // 지난 주에도 안 갔으면 스트릭 끊김
+    return 0;
+  }
+
+  /// 특정 주차부터의 연속 스트릭 길이 계산
+  static int _getStreakLength(Map<DateTime, bool> weekMap, DateTime weekStart) {
+    int streak = 0;
+    var currentWeek = weekStart;
+
+    // 과거로 거슬러 올라가며 연속된 주 계산
+    while (weekMap.containsKey(currentWeek)) {
+      streak++;
+      currentWeek = currentWeek.subtract(const Duration(days: 7));
+    }
+
+    return streak;
+  }
+
+  /// 총 방문 일수 계산
+  static int _calculateTotalDays(List<StreakItem> items) {
+    return items.where((item) => item.value > 0).length;
+  }
+
+  /// 주의 시작일(일요일) 계산
+  static DateTime _getWeekStart(DateTime date) {
+    final weekday = date.weekday % 7;  // 0: 일요일, 1-6: 월-토
+    return DateTime(date.year, date.month, date.day).subtract(Duration(days: weekday));
   }
 
   @override

--- a/lib/src/models/streak_data.dart
+++ b/lib/src/models/streak_data.dart
@@ -1,0 +1,174 @@
+/// 개별 스트릭 항목 (API 응답 구조)
+class StreakItem {
+  final DateTime date;
+  final int value;
+
+  StreakItem({
+    required this.date,
+    required this.value,
+  });
+
+  /// 서버 응답에서 생성
+  factory StreakItem.fromJson(Map<String, dynamic> json) {
+    return StreakItem(
+      date: DateTime.parse(json['date']),
+      value: (json['value'] ?? 0).toInt(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'date': date.toIso8601String().split('T')[0], // YYYY-MM-DD 형태로
+      'value': value,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'StreakItem(date: $date, value: $value)';
+  }
+}
+
+/// 스트릭 데이터 (2차원 배열 형태로 변환)
+class StreakData {
+  final List<StreakItem> items;
+  final List<List<int>> weeklyData; // 24주 x 7일 형태 (위젯에서 바로 사용)
+  final int currentStreak;
+  final int longestStreak;
+  final int totalDays;
+
+  StreakData({
+    required this.items,
+    required this.weeklyData,
+    required this.currentStreak,
+    required this.longestStreak,
+    required this.totalDays,
+  });
+
+  /// 서버 응답 데이터에서 생성 (2차원 배열 변환 포함)
+  factory StreakData.fromJson(List<dynamic> jsonList) {
+    final items = jsonList
+        .map((json) => StreakItem.fromJson(json as Map<String, dynamic>))
+        .toList();
+
+    // 2차원 배열 변환 (24주 x 7일)
+    final weeklyData = _convertToWeeklyGrid(items);
+
+    // 통계 계산
+    final stats = _calculateStats(items);
+
+    return StreakData(
+      items: items,
+      weeklyData: weeklyData,
+      currentStreak: stats['currentStreak'] ?? 0,
+      longestStreak: stats['longestStreak'] ?? 0,
+      totalDays: stats['totalDays'] ?? 0,
+    );
+  }
+
+  /// 1차원 스트릭 데이터를 24주 x 7일 2차원 배열로 변환
+  static List<List<int>> _convertToWeeklyGrid(List<StreakItem> items) {
+    const int weeks = 24;
+    const int daysPerWeek = 7;
+    
+    // 24주 x 7일 배열 초기화 (기본값 0)
+    final grid = List.generate(
+      weeks,
+      (week) => List.generate(daysPerWeek, (day) => 0),
+    );
+
+    // 현재 날짜 기준으로 24주 전, 월요일부터 시작
+    final now = DateTime.now();
+    final currentWeekday = now.weekday; // 1 = 월요일, 7 = 일요일
+    final startDate = now.subtract(Duration(days: weeks * daysPerWeek - 1 + currentWeekday - 1));
+
+    // 각 스트릭 항목을 그리드에 매핑
+    for (final item in items) {
+      final daysDiff = item.date.difference(startDate).inDays;
+      if (daysDiff >= 0 && daysDiff < weeks * daysPerWeek) {
+        final weekIndex = daysDiff ~/ daysPerWeek;
+        final dayIndex = daysDiff % daysPerWeek;
+        
+        if (weekIndex < weeks && dayIndex < daysPerWeek) {
+          grid[weekIndex][dayIndex] = item.value;
+        }
+      }
+    }
+
+    return grid;
+  }
+
+  /// 스트릭 통계 계산
+  static Map<String, int> _calculateStats(List<StreakItem> items) {
+    if (items.isEmpty) {
+      return {
+        'currentStreak': 0,
+        'longestStreak': 0,
+        'totalDays': 0,
+      };
+    }
+
+    // 날짜순 정렬
+    final sortedItems = [...items]
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    // 현재 스트릭 계산
+    int currentStreak = 0;
+    int longestStreak = 0;
+    int tempStreak = 0;
+    DateTime? lastDate;
+
+    for (final item in sortedItems) {
+      if (item.value > 0) {
+        if (lastDate != null) {
+          final daysDiff = item.date.difference(lastDate).inDays;
+          if (daysDiff == 1) {
+            // 연속된 날짜
+            tempStreak++;
+          } else {
+            // 연속이 끊김
+            longestStreak = tempStreak > longestStreak ? tempStreak : longestStreak;
+            tempStreak = 1;
+          }
+        } else {
+          // 첫 번째 항목
+          tempStreak = 1;
+        }
+        lastDate = item.date;
+      }
+    }
+
+    // 마지막 스트릭 체크
+    longestStreak = tempStreak > longestStreak ? tempStreak : longestStreak;
+
+    // 현재 스트릭 계산 (오늘까지 연속인지 확인)
+    final today = DateTime.now();
+    final todayDateOnly = DateTime(today.year, today.month, today.day);
+    
+    if (lastDate != null) {
+      final lastDateOnly = DateTime(lastDate.year, lastDate.month, lastDate.day);
+      final daysDiff = todayDateOnly.difference(lastDateOnly).inDays;
+      
+      if (daysDiff <= 1) {
+        // 어제 또는 오늘까지 연속
+        currentStreak = tempStreak;
+      } else {
+        currentStreak = 0;
+      }
+    }
+
+    // 총 제출일수 계산
+    final totalDays = sortedItems.where((item) => item.value > 0).length;
+
+    return {
+      'currentStreak': currentStreak,
+      'longestStreak': longestStreak,
+      'totalDays': totalDays,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'StreakData(items: ${items.length}, currentStreak: $currentStreak, longestStreak: $longestStreak, totalDays: $totalDays)';
+  }
+} 

--- a/lib/src/widgets/streak_widget.dart
+++ b/lib/src/widgets/streak_widget.dart
@@ -178,7 +178,7 @@ class StreakWidget extends HookWidget {
                             : '0',
                         style: TextStyle(color: colorScheme.primary),
                       ),
-                      const TextSpan(text: '일 출석'),
+                      const TextSpan(text: '주 출석'),
                     ],
                   ),
                 ),
@@ -219,8 +219,8 @@ class StreakWidget extends HookWidget {
                         child: _buildStatItem(
                           '현재 스트릭',
                           streakData != null
-                              ? '${streakData.currentStreak}일'
-                              : '0일',
+                              ? '${streakData.currentStreak}주'
+                              : '0주',
                           colorScheme,
                         ),
                       ),
@@ -228,8 +228,8 @@ class StreakWidget extends HookWidget {
                         child: _buildStatItem(
                           '최장 스트릭',
                           streakData != null
-                              ? '${streakData.longestStreak}일'
-                              : '0일',
+                              ? '${streakData.longestStreak}주'
+                              : '0주',
                           colorScheme,
                         ),
                       ),
@@ -398,8 +398,9 @@ class StreakWidget extends HookWidget {
     String value,
     TierColorScheme colorScheme,
   ) {
-    // "일"만 검은색으로, 나머지는 티어 색상으로 표시
-    if (value.endsWith('일')) {
+    // 단위("일", "주")만 검은색으로, 숫자는 티어 색상으로 표시
+    if (value.endsWith('일') || value.endsWith('주')) {
+      final unit = value.endsWith('일') ? '일' : '주';
       final numberPart = value.substring(0, value.length - 1);
       return RichText(
         text: TextSpan(
@@ -412,9 +413,9 @@ class StreakWidget extends HookWidget {
                 color: colorScheme.primary,
               ),
             ),
-            const TextSpan(
-              text: '일',
-              style: TextStyle(
+            TextSpan(
+              text: unit,
+              style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w700,
                 color: Color(0xFF1E293B),
@@ -435,8 +436,6 @@ class StreakWidget extends HookWidget {
       ),
     );
   }
-
-
 
   // 현재는 0 1 2 3 으로 구분 이후에는 최댓값 기준으로 수정 예정
   Color _getStreakColor(int submissions, TierColorScheme colorScheme) {


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 실제 스트릭 API연동

## 💬 리뷰어에게 (To Reviewer)
- 현재 fquery로 매번 탭을 누를때마다 API를 호출하는데 이부분이 괜찮을지 의문입니다. 나중에 유저가 문제를 풀고 다시 프로필탭에 들어왔을때 스트릭이 업데이트가 되어야한다고 생각해서 이렇게 처리했습니다. 캐싱이 되기때문에 속도는 빠를듯합니다. 보시고 의견 부탁드립니다.