### PR TITLE
[SWM-259] chore: 티어 명, 경험치 바, 남은 레이팅 디스플레이 수정 및 레이팅 디버깅 버튼 추가

### DIFF
--- a/lib/src/models/user_profile.dart
+++ b/lib/src/models/user_profile.dart
@@ -1,4 +1,5 @@
-/// 사용자 프로필 정보를 담는 모델
+import '../utils/tier_colors.dart';
+
 class UserProfile {
   final String nickname;
   final String statusMessage;
@@ -29,6 +30,12 @@ class UserProfile {
     required this.contributionCount,
     required this.rivalCount,
   });
+
+  /// 표시용 티어 문자열
+  String get displayTier => TierColors.getTierStringFromRating(rating);
+
+  /// 색상/아이콘 계산을 위한 티어 타입
+  TierType get tierType => TierColors.getTierTypeFromRating(rating);
 
   factory UserProfile.fromJson(Map<String, dynamic> json) {
     return UserProfile(

--- a/lib/src/screens/main_page.dart
+++ b/lib/src/screens/main_page.dart
@@ -69,8 +69,10 @@ class _MainPageState extends State<MainPage> {
     }
 
     // 유저 프로필이 로드된 경우
-    final userTier = _userProfile?.tier ?? 'Bronze III';
-    final TierType tierType = TierColors.getTierFromString(userTier);
+    // 색상 스킴은 rating 기반으로 계산
+    final TierType tierType = _userProfile != null
+        ? TierColors.getTierTypeFromRating(_userProfile!.rating)
+        : TierType.bronze;
     final TierColorScheme colorScheme = TierColors.getColorScheme(tierType);
 
     return TierProvider(

--- a/lib/src/utils/tier_colors.dart
+++ b/lib/src/utils/tier_colors.dart
@@ -114,33 +114,89 @@ class TierColors {
     }
   }
 
+  /// 상세 티어 단계 경계(start 포함, end 미포함) 목록 정의
+  /// 마지막 Master 단계는 상한이 없으므로 end를 null로 표기
+  static const List<(int start, int? end)> _stepBounds = <(int, int?)>[
+    (0, 150),
+    (150, 300),
+    (300, 450),
+    (450, 600),
+    (600, 750),
+    (750, 900),
+    (900, 1050),
+    (1050, 1200),
+    (1200, 1350),
+    (1350, 1500),
+    (1500, 1650),
+    (1650, 1800),
+    (1800, 1950),
+    (1950, 2100),
+    (2100, 2250),
+    (2250, null), // Master
+  ];
+
+  /// 현재 레이팅이 속한 단계의 시작값 반환
+  static int getCurrentStepStart(int rating) {
+    for (final (start, end) in _stepBounds) {
+      if (end == null) {
+        if (rating >= start) return start;
+      } else {
+        if (rating >= start && rating < end) return start;
+      }
+    }
+    return 0; // fallback
+  }
+
+  /// 현재 레이팅에서 다음 단계의 시작값 반환 (Master면 null)
+  static int? getNextStepStart(int rating) {
+    for (final (start, end) in _stepBounds) {
+      if (end == null) {
+        if (rating >= start) return null; // Master
+      } else {
+        if (rating >= start && rating < end) return end;
+      }
+    }
+    return _stepBounds.first.$1; // fallback (0)
+  }
+
   /// Rating 점수를 TierType으로 변환
   static TierType getTierTypeFromRating(int rating) {
-    if (rating >= 2800) return TierType.master;
-    if (rating >= 2200) return TierType.diamond; // Diamond I, II, III
-    if (rating >= 1600) return TierType.platinum; // Platinum I, II, III
-    if (rating >= 1000) return TierType.gold; // Gold I, II, III
-    if (rating >= 400) return TierType.silver; // Silver I, II, III
-    return TierType.bronze; // Bronze I, II, III
+    if (rating >= 2250) return TierType.master;      // Master
+    if (rating >= 1800) return TierType.diamond;     // Diamond I, II, III
+    if (rating >= 1350) return TierType.platinum;    // Platinum I, II, III
+    if (rating >= 900) return TierType.gold;         // Gold I, II, III
+    if (rating >= 450) return TierType.silver;       // Silver I, II, III
+    return TierType.bronze;                          // Bronze I, II, III
   }
 
   /// Rating 점수를 상세 티어 문자열로 변환
   static String getTierStringFromRating(int rating) {
-    if (rating >= 2800) return 'Master';
-    if (rating >= 2600) return 'Diamond I';
-    if (rating >= 2400) return 'Diamond II';
-    if (rating >= 2200) return 'Diamond III';
-    if (rating >= 2000) return 'Platinum I';
-    if (rating >= 1800) return 'Platinum II';
-    if (rating >= 1600) return 'Platinum III';
-    if (rating >= 1400) return 'Gold I';
-    if (rating >= 1200) return 'Gold II';
-    if (rating >= 1000) return 'Gold III';
-    if (rating >= 800) return 'Silver I';
+    // Master
+    if (rating >= 2250) return 'Master';
+
+    // Diamond
+    if (rating >= 2100) return 'Diamond I';
+    if (rating >= 1950) return 'Diamond II';
+    if (rating >= 1800) return 'Diamond III';
+
+    // Platinum
+    if (rating >= 1650) return 'Platinum I';
+    if (rating >= 1500) return 'Platinum II';
+    if (rating >= 1350) return 'Platinum III';
+
+    // Gold
+    if (rating >= 1200) return 'Gold I';
+    if (rating >= 1050) return 'Gold II';
+    if (rating >= 900) return 'Gold III';
+
+    // Silver
+    if (rating >= 750) return 'Silver I';
     if (rating >= 600) return 'Silver II';
-    if (rating >= 400) return 'Silver III';
-    if (rating >= 200) return 'Bronze I';
-    if (rating >= 100) return 'Bronze II';
+    if (rating >= 450) return 'Silver III';
+
+    // Bronze
+    if (rating >= 300) return 'Bronze I';
+    if (rating >= 150) return 'Bronze II';
     return 'Bronze III';
   }
 

--- a/lib/src/widgets/custom_app_bar.dart
+++ b/lib/src/widgets/custom_app_bar.dart
@@ -3,6 +3,10 @@ import 'dart:developer' as developer;
 import '../utils/navigation_helper.dart';
 import '../utils/color_schemes.dart';
 import '../api/auth.dart';
+import 'package:dio/dio.dart'; // TEMP: debug PATCH
+import 'package:flutter/services.dart'; // TEMP: input formatter
+import '../api/util/auth/token_storage.dart'; // TEMP: get current nickname
+import '../api/util/core/api_client.dart'; // TEMP: BASE_URL 사용
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   const CustomAppBar({super.key});
@@ -37,9 +41,95 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
             borderRadius: BorderRadius.circular(12),
           ),
           child: IconButton(
-            icon: const Icon(Icons.logout, color: AppColorSchemes.textSecondary, size: 22),
+            icon: const Icon(
+              Icons.logout,
+              color: AppColorSchemes.textSecondary,
+              size: 22,
+            ),
             onPressed: () {
               _handleLogout(context);
+            },
+          ),
+        ),
+
+        // TEMP: 디버그 - 현재 닉네임의 레이팅 PATCH 후 즉시 로그아웃
+        Container(
+          margin: const EdgeInsets.only(right: 8),
+          decoration: BoxDecoration(
+            color: AppColorSchemes.backgroundSecondary,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: IconButton(
+            icon: const Icon(
+              Icons.bug_report_outlined,
+              color: AppColorSchemes.textSecondary,
+              size: 22,
+            ),
+            onPressed: () async {
+              try {
+                final nickname =
+                    await TokenStorage.getUserNickname() ?? 'alice';
+                final controller = TextEditingController();
+                final rating = await showDialog<int>(
+                  context: context,
+                  builder: (ctx) {
+                    return AlertDialog(
+                      title: const Text('레이팅 입력'),
+                      content: TextField(
+                        controller: controller,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.digitsOnly,
+                        ],
+                        decoration: const InputDecoration(
+                          hintText: '정수값을 입력하세요',
+                        ),
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(ctx).pop(),
+                          child: const Text('취소'),
+                        ),
+                        TextButton(
+                          onPressed: () {
+                            if (controller.text.isEmpty) {
+                              Navigator.of(ctx).pop();
+                              return;
+                            }
+                            final value = int.tryParse(controller.text);
+                            Navigator.of(ctx).pop(value);
+                          },
+                          child: const Text('확인'),
+                        ),
+                      ],
+                    );
+                  },
+                );
+                if (rating == null) return;
+
+                final baseUrl = ApiClient.baseUrl ?? '';
+                final dio = Dio(
+                  BaseOptions(
+                    baseUrl: baseUrl,
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Accept': 'application/json',
+                    },
+                  ),
+                );
+
+                await dio.patch('/api/users/$nickname/rating', data: rating);
+                if (context.mounted) {
+                  _handleLogout(context);
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(SnackBar(content: Text('레이팅 갱신 실패: $e')));
+                }
+                return;
+              }
             },
           ),
         ),
@@ -88,17 +178,17 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     developer.log('로그아웃 요청', name: 'CustomAppBar');
 
     AuthHelpers.clearToken()
-        .then((_) {
-          developer.log('토큰 삭제 완료', name: 'CustomAppBar');
-          
-          // LoginPage로 이동
-          if (context.mounted) {
-            NavigationHelper.navigateToLoginAfterLogout(context);
-            developer.log('LoginPage로 이동 완료', name: 'CustomAppBar');
-          }
-        })
-        .catchError((error) {
-          developer.log('로그아웃 실패: $error', name: 'CustomAppBar');
-        });
+      .then((_) {
+        developer.log('토큰 삭제 완료', name: 'CustomAppBar');
+
+        // LoginPage로 이동
+        if (context.mounted) {
+          NavigationHelper.navigateToLoginAfterLogout(context);
+          developer.log('LoginPage로 이동 완료', name: 'CustomAppBar');
+        }
+      })
+      .catchError((error) {
+        developer.log('로그아웃 실패: $error', name: 'CustomAppBar');
+      });
   }
 }

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -51,7 +51,7 @@ class ProfileBody extends HookWidget {
 
     // 데이터 로드 성공 - 프로필 정보 사용
     final userProfile = userQuery.data!;
-    final currentTier = userProfile.tier;
+    final currentTier = userProfile.displayTier;
     final colorScheme = TierProvider.of(context);
     return DefaultTabController(
       length: 5,

--- a/lib/src/widgets/profile_header.dart
+++ b/lib/src/widgets/profile_header.dart
@@ -452,7 +452,7 @@ class _TierCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 12),
-          const _ProgressBar(),
+          _ProgressBar(currentRating: rating),
         ],
       ),
     );
@@ -486,10 +486,23 @@ class _UserRatingLabel extends StatelessWidget {
 
 /// 진행률 바
 class _ProgressBar extends StatelessWidget {
-  const _ProgressBar();
+  const _ProgressBar({required this.currentRating});
+
+  final int currentRating;
 
   @override
   Widget build(BuildContext context) {
+    // 진행률 계산: 현재 단계 시작과 다음 단계 시작을 기준으로 퍼센트 계산
+    final int start = TierColors.getCurrentStepStart(currentRating);
+    final int? next = TierColors.getNextStepStart(currentRating);
+    final double progress = () {
+      if (next == null) return 1.0; // Master는 꽉 찬 상태
+      final int span = next - start;
+      if (span <= 0) return 0.0;
+      final double ratio = (currentRating - start) / span;
+      return ratio.clamp(0.0, 1.0);
+    }();
+
     return SizedBox(
       height: 6,
       child: Stack(
@@ -501,7 +514,7 @@ class _ProgressBar extends StatelessWidget {
             ),
           ),
           FractionallySizedBox(
-            widthFactor: 0.14,
+            widthFactor: progress,
             child: Container(
               decoration: BoxDecoration(
                 color: Colors.white,

--- a/lib/src/widgets/profile_header.dart
+++ b/lib/src/widgets/profile_header.dart
@@ -387,7 +387,7 @@ class ProfileHeader extends HookWidget {
             const SizedBox(height: 12),
             _TierCard(
               colorScheme: colorScheme,
-              tierName: userProfile.tier,
+              tierName: userProfile.displayTier,
               rating: u.rating,
             ),
             const SizedBox(height: 12),

--- a/lib/src/widgets/profile_header.dart
+++ b/lib/src/widgets/profile_header.dart
@@ -430,7 +430,14 @@ class _TierCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _UserRatingLabel(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const _UserRatingLabel(),
+              _NextTierInfo(currentRating: rating),
+            ],
+          ),
           const SizedBox(height: 12),
           Text(
             tierName,
@@ -479,6 +486,33 @@ class _UserRatingLabel extends StatelessWidget {
           fontWeight: FontWeight.w600,
           letterSpacing: 0.5,
         ),
+      ),
+    );
+  }
+}
+
+/// 다음 티어까지 남은 점수 텍스트
+class _NextTierInfo extends StatelessWidget {
+  const _NextTierInfo({required this.currentRating});
+
+  final int currentRating;
+
+  @override
+  Widget build(BuildContext context) {
+    final int? nextStart = TierColors.getNextStepStart(currentRating);
+    if (nextStart == null) {
+      // Master면 표시 안 함
+      return const SizedBox.shrink();
+    }
+    final int remain = (nextStart - currentRating).clamp(0, nextStart);
+    final String nextTier = TierColors.getTierStringFromRating(nextStart);
+    return Text(
+      '$nextTier까지 ${remain}점',
+      style: const TextStyle(
+        fontSize: 10,
+        color: AppColorSchemes.backgroundPrimary,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.2,
       ),
     );
   }

--- a/lib/src/widgets/streak_widget.dart
+++ b/lib/src/widgets/streak_widget.dart
@@ -20,7 +20,8 @@ class StreakWidget extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
-    final TierType currentTier = TierColors.getTierFromString(tierName);
+    // 색상은 rating 기반으로 계산
+    final TierType currentTier = userProfile.tierType;
     final TierColorScheme colorScheme = TierColors.getColorScheme(currentTier);
 
     // fquery로 스트릭 데이터 get

--- a/lib/src/widgets/tier_widget.dart
+++ b/lib/src/widgets/tier_widget.dart
@@ -130,7 +130,7 @@ class TierWidget extends StatelessWidget {
                         fit: BoxFit.scaleDown,
                         alignment: Alignment.centerLeft,
                         child: Text(
-                          userProfile.tier,
+                          userProfile.displayTier,
                           style: TextStyle(
                             fontSize: screenWidth < 360 ? 20 : 24,
                             fontWeight: FontWeight.w800,
@@ -179,7 +179,7 @@ class TierWidget extends StatelessWidget {
                     ],
                   ),
                   child: Icon(
-                    TierColors.getTierIcon(TierColors.getTierFromString(userProfile.tier)),
+                    TierColors.getTierIcon(userProfile.tierType),
                     color: AppColorSchemes.backgroundPrimary,
                     size: screenWidth * 0.07,
                   ),


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 티어 이름을 레이팅을 기반으로 계산해서 사용하도록 변경
- 현재 티어와 레이팅의 매핑값을 수정
- 남은 경험치를 상단에 표시
- 경험치 바를 현재 경험치에 맞춰서 표시
- 레이팅 디버깅용 버튼 추가

 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**