### PR TITLE
[SWM-264] fix: 유저의 레이팅을 직접 변경 할 수 있는 디버깅용 툴 수정

### DIFF
--- a/lib/src/widgets/custom_app_bar.dart
+++ b/lib/src/widgets/custom_app_bar.dart
@@ -8,12 +8,14 @@ import 'package:flutter/services.dart'; // TEMP: input formatter
 import '../api/util/auth/token_storage.dart'; // TEMP: get current nickname
 import '../api/util/core/api_client.dart'; // TEMP: BASE_URL 사용
 import 'package:flutter/foundation.dart'; // kDebugMode
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   const CustomAppBar({super.key});
 
   @override
   Widget build(BuildContext context) {
+
     return AppBar(
       backgroundColor: AppColorSchemes.backgroundPrimary,
       elevation: 0,
@@ -116,11 +118,13 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
                     headers: {
                       'Content-Type': 'application/json',
                       'Accept': 'application/json',
+                      'Authorization': 'Bearer ${dotenv.env['PATCH_TOKEN']}',
                     },
                   ),
                 );
+                print('PATCH_TOKEN: ${dotenv.env['PATCH_TOKEN']}');
 
-                await dio.patch('/api/users/$nickname/rating', data: rating);
+                await dio.patch('/api/admin/users/$nickname/rating', data: rating);
                 if (!context.mounted) return;
                 _handleLogout(context);
               } catch (e) {

--- a/lib/src/widgets/custom_app_bar.dart
+++ b/lib/src/widgets/custom_app_bar.dart
@@ -122,7 +122,6 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
                     },
                   ),
                 );
-                print('PATCH_TOKEN: ${dotenv.env['PATCH_TOKEN']}');
 
                 await dio.patch('/api/admin/users/$nickname/rating', data: rating);
                 if (!context.mounted) return;


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 디버깅용 툴 동작하도록 수정

## ✨ 변경 사항 (Changes)
- PATCH_TOKEN을 .env에 추가
- 디버깅용 툴을 사용하여 현재 유저의 레이팅을 변경가능

## ✅ 테스트 방법 (How to Test)
- 상단 앱바의 debug 아이콘 버튼을 누르고 레이팅을 변경하면 로그아웃됩니다.

[ ] ex) google OAuth 연동

 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**