### PR TITLE
[SWM-289] feat: 프로필 자동새로고침 및 랭킹 새로고침 로직 적용

### DIFF
--- a/lib/src/screens/main_page.dart
+++ b/lib/src/screens/main_page.dart
@@ -111,7 +111,6 @@ class MainPageState extends State<MainPage> {
           onTap: (tab) {
             // 현재 페이지 내에서 탭 변경
             setState(() {
-              final wasProfile = _currentTab == BottomNavTab.profile;
               final willBeProfile = tab == BottomNavTab.profile;
               _currentTab = tab;
               if (willBeProfile) {

--- a/lib/src/screens/main_page.dart
+++ b/lib/src/screens/main_page.dart
@@ -33,6 +33,7 @@ class MainPageState extends State<MainPage> {
   bool _isLoading = true;
   String? _error;
   int? _gymIdForSearch;
+  int _profileRefreshSignal = 0;
 
   @override
   void initState() {
@@ -94,7 +95,7 @@ class MainPageState extends State<MainPage> {
         index: _currentTab.index,
         children: [
           // 0: 프로필
-          const ProfileBody(),
+          ProfileBody(refreshSignal: _profileRefreshSignal),
           // 1: 리더보드
           const LeaderboardBody(),
           // 2: 검색
@@ -110,7 +111,13 @@ class MainPageState extends State<MainPage> {
           onTap: (tab) {
             // 현재 페이지 내에서 탭 변경
             setState(() {
+              final wasProfile = _currentTab == BottomNavTab.profile;
+              final willBeProfile = tab == BottomNavTab.profile;
               _currentTab = tab;
+              if (willBeProfile) {
+                // 프로필 탭으로 전환되거나 재선택 시 리프레시 신호 증가
+                _profileRefreshSignal++;
+              }
             });
           },
         ),

--- a/lib/src/screens/main_page.dart
+++ b/lib/src/screens/main_page.dart
@@ -33,7 +33,6 @@ class MainPageState extends State<MainPage> {
   bool _isLoading = true;
   String? _error;
   int? _gymIdForSearch;
-  int _profileRefreshSignal = 0;
 
   @override
   void initState() {
@@ -95,7 +94,7 @@ class MainPageState extends State<MainPage> {
         index: _currentTab.index,
         children: [
           // 0: 프로필
-          ProfileBody(refreshSignal: _profileRefreshSignal),
+          const ProfileBody(),
           // 1: 리더보드
           const LeaderboardBody(),
           // 2: 검색
@@ -111,12 +110,7 @@ class MainPageState extends State<MainPage> {
           onTap: (tab) {
             // 현재 페이지 내에서 탭 변경
             setState(() {
-              final willBeProfile = tab == BottomNavTab.profile;
               _currentTab = tab;
-              if (willBeProfile) {
-                // 프로필 탭으로 전환되거나 재선택 시 리프레시 신호 증가
-                _profileRefreshSignal++;
-              }
             });
           },
         ),

--- a/lib/src/widgets/leaderboard_body.dart
+++ b/lib/src/widgets/leaderboard_body.dart
@@ -226,29 +226,35 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
             );
           }
 
-          return NotificationListener<ScrollNotification>(
-            onNotification: (notification) {
-              if (notification is ScrollEndNotification ||
-                  notification is UserScrollNotification) {
-                final metrics = notification.metrics;
-                if (metrics.pixels + _scrollThreshold >= metrics.maxScrollExtent) {
-                  _loadMore(type);
-                }
-              }
-              return false;
+          return RefreshIndicator(
+            onRefresh: () async {
+              await _loadInitial(type);
             },
-            child: ListView.builder(
-              itemCount: items.length + ((_hasMoreByType[type] == true) ? 1 : 0),
-              itemBuilder: (context, index) {
-                if (index >= items.length) {
-                  // 로딩 인디케이터 셀
-                  return const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 16),
-                    child: Center(child: CircularProgressIndicator()),
-                  );
+            child: NotificationListener<ScrollNotification>(
+              onNotification: (notification) {
+                if (notification is ScrollEndNotification ||
+                    notification is UserScrollNotification) {
+                  final metrics = notification.metrics;
+                  if (metrics.pixels + _scrollThreshold >= metrics.maxScrollExtent) {
+                    _loadMore(type);
+                  }
                 }
-                return _buildLeaderboardItem(items[index]);
+                return false;
               },
+              child: ListView.builder(
+                physics: const AlwaysScrollableScrollPhysics(),
+                itemCount: items.length + ((_hasMoreByType[type] == true) ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index >= items.length) {
+                    // 로딩 인디케이터 셀
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16),
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+                  return _buildLeaderboardItem(items[index]);
+                },
+              ),
             ),
           );
         },

--- a/lib/src/widgets/leaderboard_body.dart
+++ b/lib/src/widgets/leaderboard_body.dart
@@ -66,6 +66,7 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
     } catch (e) {
       _errorByType[type] = e.toString().replaceFirst('Exception: ', '');
     } finally {
+      if (!mounted) return;
       _isLoadingByType[type] = false;
       setState(() {});
     }
@@ -91,6 +92,7 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
     } catch (e) {
       _errorByType[type] = e.toString().replaceFirst('Exception: ', '');
     } finally {
+      if (!mounted) return;
       _isLoadingByType[type] = false;
       setState(() {});
     }

--- a/lib/src/widgets/leaderboard_body.dart
+++ b/lib/src/widgets/leaderboard_body.dart
@@ -66,9 +66,10 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
     } catch (e) {
       _errorByType[type] = e.toString().replaceFirst('Exception: ', '');
     } finally {
-      if (!mounted) return;
-      _isLoadingByType[type] = false;
-      setState(() {});
+      if (mounted) {
+        _isLoadingByType[type] = false;
+        setState(() {});
+      }
     }
   }
 
@@ -92,9 +93,10 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
     } catch (e) {
       _errorByType[type] = e.toString().replaceFirst('Exception: ', '');
     } finally {
-      if (!mounted) return;
-      _isLoadingByType[type] = false;
-      setState(() {});
+      if (mounted) {
+        _isLoadingByType[type] = false;
+        setState(() {});
+      }
     }
   }
 

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -27,11 +27,22 @@ class ProfileBody extends HookWidget {
       'user_profile',
     ], UserApi.getUserProfile);
 
-    // 5분 주기 자동 리프레시
+    // 마지막 리프레시 시각 추적
+    final lastRefreshTime = useRef<DateTime?>(null);
+
+    // 진입 시 5분 경과 시 즉시 리프레시 + 5분 주기 자동 리프레시
     useEffect(() {
+      if (lastRefreshTime.value != null &&
+          DateTime.now().difference(lastRefreshTime.value!).inMinutes >= 5) {
+        developer.log('프로필 진입 시 5분 경과로 즉시 리프레시', name: 'ProfileBody');
+        userQuery.refetch();
+        lastRefreshTime.value = DateTime.now();
+      }
+
       final timer = Timer.periodic(const Duration(minutes: 5), (_) {
         developer.log('프로필 자동 리프레시', name: 'ProfileBody');
         userQuery.refetch();
+        lastRefreshTime.value = DateTime.now();
       });
       return timer.cancel;
     }, const []);

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fquery/fquery.dart';
+import 'dart:async';
+import 'dart:developer' as developer;
 import 'profile_header.dart';
 import 'tier_widget.dart';
 import 'history_widget.dart';
@@ -16,9 +18,7 @@ import 'submission_list_widget.dart';
 /// 로딩/에러 상태 처리 및 탭 구조 관리
 
 class ProfileBody extends HookWidget {
-  const ProfileBody({super.key, this.refreshSignal = 0});
-
-  final int refreshSignal;
+  const ProfileBody({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -27,16 +27,14 @@ class ProfileBody extends HookWidget {
       'user_profile',
     ], UserApi.getUserProfile);
 
-    // 포커스/탭 재진입 시 자동 리로드
-    final didInitRef = useRef(false);
+    // 5분 주기 자동 리프레시
     useEffect(() {
-      if (didInitRef.value) {
+      final timer = Timer.periodic(const Duration(minutes: 5), (_) {
+        developer.log('프로필 자동 리프레시', name: 'ProfileBody');
         userQuery.refetch();
-      } else {
-        didInitRef.value = true;
-      }
-      return null;
-    }, [refreshSignal]);
+      });
+      return timer.cancel;
+    }, const []);
 
     // 로딩 중 표시
     if (userQuery.isLoading) {

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -16,7 +16,9 @@ import 'submission_list_widget.dart';
 /// 로딩/에러 상태 처리 및 탭 구조 관리
 
 class ProfileBody extends HookWidget {
-  const ProfileBody({super.key});
+  const ProfileBody({super.key, this.refreshSignal = 0});
+
+  final int refreshSignal;
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +26,17 @@ class ProfileBody extends HookWidget {
     final userQuery = useQuery<UserProfile, Exception>([
       'user_profile',
     ], UserApi.getUserProfile);
+
+    // 포커스/탭 재진입 시 자동 리로드
+    final didInitRef = useRef(false);
+    useEffect(() {
+      if (didInitRef.value) {
+        userQuery.refetch();
+      } else {
+        didInitRef.value = true;
+      }
+      return null;
+    }, [refreshSignal]);
 
     // 로딩 중 표시
     if (userQuery.isLoading) {
@@ -86,7 +99,6 @@ class ProfileBody extends HookWidget {
                     _buildTab('히스토리'),
                     _buildTab('스트릭'),
                     _buildTab('내 영상'),
-                    // _buildTab('분야별 티어'), // 임시 비노출
                     _buildTab('제출 내역'),
                   ],
                 ),

--- a/lib/src/widgets/submission_list_widget.dart
+++ b/lib/src/widgets/submission_list_widget.dart
@@ -13,7 +13,6 @@ class SubmissionListWidget extends HookWidget {
   Widget build(BuildContext context) {
     final submissionsState = useState<List<Submission>>([]);
     final isLoading = useState(false);
-    final isRefreshing = useState(false);
     final isLoadingMore = useState(false);
     final nextCursor = useState<String?>(null);
     final hasNext = useState<bool>(true);
@@ -36,20 +35,6 @@ class SubmissionListWidget extends HookWidget {
         ).showSnackBar(SnackBar(content: Text('제출 내역을 불러오지 못했습니다: $e')));
       } finally {
         isLoading.value = false;
-      }
-    }
-
-    Future<void> refresh() async {
-      isRefreshing.value = true;
-      try {
-        await fetchSubmissions();
-      } catch (e) {
-        if (!context.mounted) return;
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('새로고침 실패: $e')));
-      } finally {
-        isRefreshing.value = false;
       }
     }
 
@@ -83,50 +68,47 @@ class SubmissionListWidget extends HookWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        return RefreshIndicator(
-          onRefresh: refresh,
-          child: NotificationListener<ScrollNotification>(
-            onNotification: (notification) {
-              if (notification.metrics.pixels >=
-                  notification.metrics.maxScrollExtent - 200) {
-                loadMore();
-              }
-              return false;
-            },
-            child: isLoading.value
-                ? const Center(
-                    child: Padding(
-                      padding: EdgeInsets.all(24),
-                      child: CircularProgressIndicator(),
-                    ),
-                  )
-                : submissionsState.value.isEmpty
-                ? ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    children: [
-                      const SizedBox(height: 120),
-                      _buildEmptyState(),
-                      const SizedBox(height: 120),
-                    ],
-                  )
-                : ListView.separated(
-                    padding: const EdgeInsets.all(16),
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    itemCount:
-                        submissionsState.value.length + (hasNext.value ? 1 : 0),
-                    separatorBuilder: (_, __) => const SizedBox(height: 12),
-                    itemBuilder: (context, index) {
-                      if (index >= submissionsState.value.length) {
-                        return const Padding(
-                          padding: EdgeInsets.symmetric(vertical: 16),
-                          child: Center(child: CircularProgressIndicator()),
-                        );
-                      }
-                      final item = submissionsState.value[index];
-                      return _SubmissionListItem(item: item);
-                    },
+        return NotificationListener<ScrollNotification>(
+          onNotification: (notification) {
+            if (notification.metrics.pixels >=
+                notification.metrics.maxScrollExtent - 200) {
+              loadMore();
+            }
+            return false;
+          },
+          child: isLoading.value
+              ? const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(24),
+                    child: CircularProgressIndicator(),
                   ),
-          ),
+                )
+              : submissionsState.value.isEmpty
+                  ? ListView(
+                      physics: const ClampingScrollPhysics(),
+                      children: [
+                        const SizedBox(height: 120),
+                        _buildEmptyState(),
+                        const SizedBox(height: 120),
+                      ],
+                    )
+                  : ListView.separated(
+                      padding: const EdgeInsets.all(16),
+                      physics: const ClampingScrollPhysics(),
+                      itemCount: submissionsState.value.length +
+                          (hasNext.value ? 1 : 0),
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        if (index >= submissionsState.value.length) {
+                          return const Padding(
+                            padding: EdgeInsets.symmetric(vertical: 16),
+                            child: Center(child: CircularProgressIndicator()),
+                          );
+                        }
+                        final item = submissionsState.value[index];
+                        return _SubmissionListItem(item: item);
+                      },
+                    ),
         );
       },
     );


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 다른 탭에서 프로필 탭으로 이동시 프로필 페이지 리로드 기능 추가
- 랭킹은 상단에 끌어내림을 통해서 리로드 되도록 기능 추가
- 제출 내역은 탭 내부에서 새로고침 되는데 이것은 탭이동으로 새로 고침되도록 수정
탭 내부 이동에서도 새롭게 새로 고침됨

 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**