### PR TITLE
[SWM-280] ‘라이벌 수’ → ‘현재 스트릭’ 교체 및 알림/코멘트 UI 비활성화

### DIFF
--- a/lib/src/models/user_profile.dart
+++ b/lib/src/models/user_profile.dart
@@ -13,7 +13,7 @@ class UserProfile {
   final int solvedCount;
   final int submissionCount;
   final int contributionCount;
-  final int rivalCount;
+  // 라이벌 수는 더 이상 사용하지 않음. 현재 스트릭을 사용합니다.
 
   UserProfile({
     required this.nickname,
@@ -28,7 +28,6 @@ class UserProfile {
     required this.solvedCount,
     required this.submissionCount,
     required this.contributionCount,
-    required this.rivalCount,
   });
 
   /// 표시용 티어 문자열
@@ -53,7 +52,6 @@ class UserProfile {
       solvedCount: json['solvedCount'] ?? 0,
       submissionCount: json['submissionCount'] ?? 0,
       contributionCount: json['contributionCount'] ?? 0,
-      rivalCount: json['rivalCount'] ?? 0,
     );
   }
 
@@ -71,7 +69,6 @@ class UserProfile {
       'solvedCount': solvedCount,
       'submissionCount': submissionCount,
       'contributionCount': contributionCount,
-      'rivalCount': rivalCount,
     };
   }
 

--- a/lib/src/screens/problem_detail_page.dart
+++ b/lib/src/screens/problem_detail_page.dart
@@ -21,7 +21,8 @@ class ProblemDetailPage extends StatefulWidget {
 }
 
 class _ProblemDetailPageState extends State<ProblemDetailPage> {
-  final TextEditingController _commentController = TextEditingController();
+  // 코멘트 기능 비활성화: 컨트롤러 주석 처리
+  // final TextEditingController _commentController = TextEditingController();
   String? _gymName; // 클라이밍장 이름 저장
 
   @override
@@ -32,7 +33,8 @@ class _ProblemDetailPageState extends State<ProblemDetailPage> {
 
   @override
   void dispose() {
-    _commentController.dispose();
+    // 코멘트 기능 비활성화
+    // _commentController.dispose();
     super.dispose();
   }
 
@@ -94,8 +96,8 @@ class _ProblemDetailPageState extends State<ProblemDetailPage> {
                   _buildSubmitButton(),
                   const SizedBox(height: 24),
 
-                  // 코멘트 섹션
-                  _buildCommentSection(),
+                  // 코멘트 섹션 (비활성화)
+                  // _buildCommentSection(),
                 ],
               ),
             ),
@@ -270,99 +272,79 @@ class _ProblemDetailPageState extends State<ProblemDetailPage> {
     );
   }
 
-  /// 코멘트 섹션 위젯
-  Widget _buildCommentSection() {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColorSchemes.backgroundPrimary,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: AppColorSchemes.lightShadow,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 코멘트 제목
-          const Text(
-            '코멘트',
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w600,
-              color: AppColorSchemes.textPrimary,
-            ),
-          ),
-          const SizedBox(height: 16),
+  // 코멘트 섹션 비활성화
+  // Widget _buildCommentSection() {
+  //   return Container(
+  //     padding: const EdgeInsets.all(16),
+  //     decoration: BoxDecoration(
+  //       color: AppColorSchemes.backgroundPrimary,
+  //       borderRadius: BorderRadius.circular(16),
+  //       boxShadow: AppColorSchemes.lightShadow,
+  //     ),
+  //     child: Column(
+  //       crossAxisAlignment: CrossAxisAlignment.start,
+  //       children: [
+  //         const Text('코멘트',
+  //           style: TextStyle(
+  //             fontSize: 18,
+  //             fontWeight: FontWeight.w600,
+  //             color: AppColorSchemes.textPrimary,
+  //           ),
+  //         ),
+  //         const SizedBox(height: 16),
+  //         TextField(
+  //           controller: _commentController,
+  //           maxLines: 3,
+  //           decoration: InputDecoration(
+  //             hintText: '코멘트를 입력하세요...',
+  //             hintStyle: const TextStyle(color: AppColorSchemes.textTertiary),
+  //             border: OutlineInputBorder(
+  //               borderRadius: BorderRadius.circular(12),
+  //               borderSide: const BorderSide(color: AppColorSchemes.borderPrimary),
+  //             ),
+  //             focusedBorder: OutlineInputBorder(
+  //               borderRadius: BorderRadius.circular(12),
+  //               borderSide: const BorderSide(color: AppColorSchemes.accentBlue),
+  //             ),
+  //           ),
+  //         ),
+  //         const SizedBox(height: 12),
+  //         Row(
+  //           mainAxisAlignment: MainAxisAlignment.end,
+  //           children: [
+  //             ElevatedButton(
+  //               onPressed: _submitComment,
+  //               style: ElevatedButton.styleFrom(
+  //                 backgroundColor: AppColorSchemes.accentBlue,
+  //                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+  //               ),
+  //               child: const Text('작성',
+  //                 style: TextStyle(
+  //                   color: AppColorSchemes.backgroundPrimary,
+  //                   fontWeight: FontWeight.w600,
+  //                 ),
+  //               ),
+  //             ),
+  //           ],
+  //         ),
+  //       ],
+  //     ),
+  //   );
+  // }
 
-          // 코멘트 입력 필드
-          TextField(
-            controller: _commentController,
-            maxLines: 3,
-            decoration: InputDecoration(
-              hintText: '코멘트를 입력하세요...',
-              hintStyle: const TextStyle(
-                color: AppColorSchemes.textTertiary,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: AppColorSchemes.borderPrimary,
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: AppColorSchemes.accentBlue,
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-
-          // 코멘트 작성 버튼
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              ElevatedButton(
-                onPressed: () {
-                  // 코멘트 작성 로직
-                  _submitComment();
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColorSchemes.accentBlue,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-                child: const Text(
-                  '작성',
-                  style: TextStyle(
-                    color: AppColorSchemes.backgroundPrimary,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// 코멘트 제출
-  void _submitComment() {
-    if (_commentController.text.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('코멘트를 입력해주세요.')),
-      );
-      return;
-    }
-
-    // 코멘트 제출 로직 구현
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('코멘트가 작성되었습니다!')),
-    );
-    _commentController.clear();
-  }
+  // 코멘트 제출 비활성화
+  // void _submitComment() {
+  //   if (_commentController.text.trim().isEmpty) {
+  //     ScaffoldMessenger.of(context).showSnackBar(
+  //       const SnackBar(content: Text('코멘트를 입력해주세요.')),
+  //     );
+  //     return;
+  //   }
+  //   ScaffoldMessenger.of(context).showSnackBar(
+  //     const SnackBar(content: Text('코멘트가 작성되었습니다!')),
+  //   );
+  //   _commentController.clear();
+  // }
 
   // 색상 계산은 ColorCodes에서 처리함
 } 

--- a/lib/src/widgets/custom_app_bar.dart
+++ b/lib/src/widgets/custom_app_bar.dart
@@ -119,22 +119,22 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
           ),
         ),
 
-        // 알림
-        Container(
-          margin: const EdgeInsets.only(right: 8),
-          decoration: BoxDecoration(
-            color: AppColorSchemes.backgroundSecondary,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: IconButton(
-            icon: const Icon(
-              Icons.notifications_outlined,
-              color: AppColorSchemes.textSecondary,
-              size: 22,
-            ),
-            onPressed: () {},
-          ),
-        ),
+        // 알림 버튼 (비활성화/주석 처리)
+        // Container(
+        //   margin: const EdgeInsets.only(right: 8),
+        //   decoration: BoxDecoration(
+        //     color: AppColorSchemes.backgroundSecondary,
+        //     borderRadius: BorderRadius.circular(12),
+        //   ),
+        //   child: IconButton(
+        //     icon: const Icon(
+        //       Icons.notifications_outlined,
+        //       color: AppColorSchemes.textSecondary,
+        //       size: 22,
+        //     ),
+        //     onPressed: () {},
+        //   ),
+        // ),
         // 설정
         Container(
           margin: const EdgeInsets.only(right: 16),

--- a/lib/src/widgets/profile_header.dart
+++ b/lib/src/widgets/profile_header.dart
@@ -632,7 +632,11 @@ class _StatsRow extends StatelessWidget {
           Icons.add_circle_outline,
         ),
         const SizedBox(width: 12),
-        card(userProfile.rivalCount.toString(), '명의 라이벌', Icons.people_outline),
+        card(
+          userProfile.currentStreak.toString(),
+          '현재 스트릭',
+          Icons.local_fire_department,
+        ),
       ],
     );
   }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 프로필 통계의 “라이벌 수”를 “현재 스트릭”으로 교체
- 앱바 알림 버튼 비활성화(주석 처리)
- 문제 상세(제출) 뷰의 “코멘트” 섹션 비활성화(주석 처리)

## ✨ 변경 사항 (Changes)

- [ ] lib/src/models/user_profile.dart: rivalCount 필드 및 JSON 매핑 제거, currentStreak만 사용
- [ ] lib/src/widgets/profile_header.dart: 통계 카드 라벨/아이콘 변경(현재 스트릭, fire 아이콘)
- [ ] lib/src/widgets/custom_app_bar.dart: 알림 아이콘 컨테이너 블록 주석 처리
- [ ] lib/src/screens/problem_detail_page.dart: 코멘트 컨트롤러/섹션/제출 로직 전체 주석 처리

## ✅ 테스트 방법 (How to Test)

- flutter analyze
- 앱 실행 후 프로필 화면 확인: 통계 마지막 카드가 “현재 스트릭”으로 표시되는지
- 앱바에서 알림 아이콘이 보이지 않는지
- 문제 상세 페이지에서 코멘트 입력 섹션이 표시되지 않는지

## 🚀관련 이슈 (Related Issue)

Closes: SWM-280

 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**