### PR TITLE
[SWM-304] fix: 주석 처리된 코드 제거 및 백엔드 API 연동을 위한 TODO 추가

### DIFF
--- a/lib/src/widgets/tier_widget.dart
+++ b/lib/src/widgets/tier_widget.dart
@@ -73,44 +73,45 @@ class TierWidget extends StatelessWidget {
                     ),
                   ),
                 ),
-                const SizedBox(width: 8),
-                Flexible(
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: AppColorSchemes.backgroundTertiary,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          '#${userProfile.ranking}',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w700,
-                            color: colorScheme.primary,
-                          ),
-                        ),
-                        const SizedBox(width: 6),
-                        const Flexible(
-                          child: Text(
-                            '상위 0.1%',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: AppColorSchemes.textSecondary,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+                // TODO: 백엔드에서 전체 유저 수와 랭킹 %를 API로 제공하면 주석 해제
+                // const SizedBox(width: 8),
+                // Flexible(
+                //   child: Container(
+                //     padding: const EdgeInsets.symmetric(
+                //       horizontal: 12,
+                //       vertical: 6,
+                //     ),
+                //     decoration: BoxDecoration(
+                //       color: AppColorSchemes.backgroundTertiary,
+                //       borderRadius: BorderRadius.circular(20),
+                //     ),
+                //     child: Row(
+                //       mainAxisSize: MainAxisSize.min,
+                //       children: [
+                //         Text(
+                //           '#${userProfile.ranking}',
+                //           style: TextStyle(
+                //             fontSize: 14,
+                //             fontWeight: FontWeight.w700,
+                //             color: colorScheme.primary,
+                //           ),
+                //         ),
+                //         const SizedBox(width: 6),
+                //         Flexible(
+                //           child: Text(
+                //             '상위 0.1%',
+                //             style: TextStyle(
+                //               fontSize: 12,
+                //               color: AppColorSchemes.textSecondary,
+                //               fontWeight: FontWeight.w500,
+                //             ),
+                //             overflow: TextOverflow.ellipsis,
+                //           ),
+                //         ),
+                //       ],
+                //     ),
+                //   ),
+                // ),
               ],
             ),
 


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 하드코딩된 상위 %를 직접 리더보드 API로 계산해야하기에 복잡도 증가

## ✨ 변경 사항 (Changes)
- 유저의 티어위젯에서 우측의 등수와 상위 % 임시 주석 처리


## 💬 리뷰어에게 (To Reviewer)

- 추후 백엔드에서 유저의 정보를 조회할때 등수와 상위 %(또는 전체 유저 수)를 같이 제공해주면 좋을거 같습니다.

## 📋 앞으로의 과제 (Todo)
[ ] 백엔드 API 변경 후 등수 및 상위% 주석해제

 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**