### PR TITLE
[SWM-346] fix: GA로 인한 광고 권한 Menifest.xml에 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <application
         android:label="ClimbX"
         android:name="${applicationName}"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+39
+version: 1.0.5+55
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
## 📝 작업 내용 (Description)
<img width="1026" height="396" alt="image" src="https://github.com/user-attachments/assets/80cd3c08-9202-4e24-988e-240c9b077a28" />
현재 안드로이드 출시버전에 firebase를 붙임으로 인해서 광고 권한이 AndroidMenifest.xml에 추가되어야함

- 버전을 `1.0.5+55`로 수정
- AndroidMenifest.xml에 `<uses-permission android:name="com.google.android.gms.permission.AD_ID"/>`추가

 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**