### PR TITLE
[SWM-333] refact: 리더보드 예외처리 개선

### DIFF
--- a/lib/src/widgets/leaderboard_body.dart
+++ b/lib/src/widgets/leaderboard_body.dart
@@ -361,6 +361,8 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
               children: [
                 Text(
                   user.nickname,
+                  maxLines: 1,                        // 줄 제한
+                  overflow: TextOverflow.ellipsis,    // 줄 초과 시 생략
                   style: const TextStyle(
                     fontWeight: FontWeight.w600,
                     fontSize: 16,

--- a/lib/src/widgets/leaderboard_body.dart
+++ b/lib/src/widgets/leaderboard_body.dart
@@ -322,17 +322,21 @@ class _LeaderboardBodyState extends State<LeaderboardBody>
       ),
       child: Row(
         children: [
-          // 등수
-          Text(
-            '${user.ranking}',
-            style: const TextStyle(
-              color: AppColorSchemes.textSpecial,
-              fontWeight: FontWeight.w700,
-              fontSize: 20,
+          // 등수 (고정 너비 숫자 3개만큼 미리 추가)
+          SizedBox(
+            width: 45,
+            child: Text(
+              '${user.ranking}',
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: AppColorSchemes.textSpecial,
+                fontWeight: FontWeight.w700,
+                fontSize: 20,
+              ),
             ),
           ),
 
-          const SizedBox(width: 32),
+          const SizedBox(width: 16),
 
           // 프로필 사진
           Container(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.5+55
+version: 1.0.6+60
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 랭킹 아이템에서 숫자의 자릿수에 따라 유저의 프로필이 밀리던 문제 해결
  - 최소 3자리를 기준으로 공간을 두고 가운데 숫자를 두었습니다.
- 유저의 프로필 이름이 길때 랭킹에 모두 노출되는 문제를 해결하기 위해 `maxLines`, `overflows`추가


 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**