### PR TITLE
[SWM-332] feat: 뒤로가기 스와이프로 구현

### DIFF
--- a/lib/src/utils/navigation_helper.dart
+++ b/lib/src/utils/navigation_helper.dart
@@ -209,7 +209,7 @@ class NavigationHelper {
   }
 
   /// 공통 페이지 라우트 생성 (스와이프로 뒤로가기 지원)
-  static CupertinoPageRoute<T> _createPageRoute<T extends Widget>(T page) {
+  static CupertinoPageRoute<T> _createPageRoute<T>(Widget page) {
     return CupertinoPageRoute<T>(
       builder: (context) => page,
     );

--- a/lib/src/utils/navigation_helper.dart
+++ b/lib/src/utils/navigation_helper.dart
@@ -1,5 +1,5 @@
 import 'dart:developer' as developer;
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import '../screens/main_page.dart';
 import '../screens/settings_page.dart';
 import '../screens/markdown_viewer_page.dart';
@@ -208,12 +208,10 @@ class NavigationHelper {
     );
   }
 
-  /// 공통 페이지 라우트 생성 (애니메이션 없음)
-  static PageRouteBuilder<T> _createPageRoute<T extends Widget>(T page) {
-    return PageRouteBuilder<T>(
-      pageBuilder: (context, animation, secondaryAnimation) => page,
-      transitionDuration: Duration.zero,
-      reverseTransitionDuration: Duration.zero,
+  /// 공통 페이지 라우트 생성 (스와이프로 뒤로가기 지원)
+  static CupertinoPageRoute<T> _createPageRoute<T extends Widget>(T page) {
+    return CupertinoPageRoute<T>(
+      builder: (context) => page,
     );
   }
 } 


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 왼쪽 스와이프를 통해서 새롭게 켜진 창을 스와이프로 뒤로가기로 구현

 NavigationHelper.navigateToSettings(context)
    ↓
  Navigator.push(context, _createPageRoute(SettingsPage()))
    ↓
  CupertinoPageRoute 생성 (자동으로 스와이프 백 활성화)
    ↓
  설정 페이지 표시 + 스와이프 제스처 리스너 등록

다음과 같은 과정으로 동작합니다.


 ## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**